### PR TITLE
Tone down language in simplified IEEE paper for formal, readable prose

### DIFF
--- a/paper/mic-paper-simplified-ieee.tex
+++ b/paper/mic-paper-simplified-ieee.tex
@@ -52,17 +52,17 @@ Data tables are reproduced from the full manuscript; figures are omitted.}%
 
 % ============================================================
 \begin{abstract}
-Medical images must be stored and transmitted losslessly---a radiologist must
-see exactly what the scanner produced---and they are ``deep,'' carrying 10--16
-bits per pixel rather than the 8 bits of an ordinary photo. That deep format is
-where most compression tools stumble, because nearly all of them were built for
-8-bit data. This paper describes MIC (Medical Image Codec), a lossless codec
-that works directly on 16-bit data instead of chopping each pixel into two
-bytes. MIC chains three simple stages---a spatial predictor, a 16-bit
-run-length encoder, and a large-alphabet entropy coder called Finite State
-Entropy (FSE, a fast table-driven form of asymmetric numeral systems)---and
-adds a multi-state decoder that keeps the CPU busier to speed up
-decompression. On 21 real DICOM images across nine modalities, MIC compresses
+Medical images must be stored and transmitted losslessly, since a radiologist
+must see exactly what the scanner produced, and they are ``deep,'' carrying
+10--16 bits per pixel rather than the 8 bits of an ordinary photo. That deep
+format is where most compression tools perform poorly, because nearly all of
+them were built for 8-bit data. This paper describes MIC (Medical Image Codec),
+a lossless codec that works directly on 16-bit data instead of splitting each
+pixel into two bytes. MIC chains three simple stages, a spatial predictor, a
+16-bit run-length encoder, and a large-alphabet entropy coder called Finite
+State Entropy (FSE, a fast table-driven form of asymmetric numeral systems),
+and adds a multi-state decoder that keeps the CPU more fully utilized to speed
+up decompression. On 21 real DICOM images across nine modalities, MIC compresses
 5--22\% better (14\% on average) than a strong general-purpose baseline
 (Delta\,+\,Zstandard), reaches an average compression ratio of
 3.46$\times$ (essentially tied with High-Throughput JPEG~2000 at 3.45$\times$
@@ -83,11 +83,12 @@ imaging.
 \section{Why Medical Images Need a Different Codec}
 \label{sec:intro}
 
-\IEEEPARstart{A}{modern} scanner produces a lot of data. One digital breast
-tomosynthesis view alone can be 60+ image slices and over 600\,MB; a full
-screening study tops 2\,GB uncompressed. Hospitals store and move enormous
-volumes of this data every day, so good lossless compression directly affects
-storage cost, network load, and how fast images appear on a viewer.
+\IEEEPARstart{A}{modern} scanner produces a great deal of data. A single
+digital breast tomosynthesis view can comprise 60 or more image slices and over
+600\,MB; a full screening study can exceed 2\,GB uncompressed. Hospitals store
+and move very large volumes of this data every day, so effective lossless
+compression directly affects storage cost, network load, and how quickly images
+appear in a viewer.
 
 DICOM~\cite{dicom}, the medical imaging standard, already supports several
 lossless formats---JPEG~2000~\cite{taubman2002}, HTJ2K~\cite{htj2k2019},
@@ -97,20 +98,20 @@ it is to implement~\cite{liu2017,clunie2000}. JPEG~2000 and HTJ2K compress well
 but rely on fairly heavy machinery. JPEG-LS usually gets the smallest files.
 Plain run-length coding is simple but barely compresses.
 
-\subsection{The core problem: everything assumes 8-bit data}
+\subsection{The core problem: most coders assume 8-bit data}
 
-Here is the observation the whole paper is built on. The popular entropy
-coders---Huffman, arithmetic coding, the LZ77 family, and the FSE/ANS coder
-inside Zstandard~\cite{rfc8878}---were all designed for \textbf{8-bit byte
-streams}, where there are only 256 possible symbols. Medical images break that
-assumption: a 16-bit pixel has up to 65,536 possible values.
+This is the central observation behind the paper. The widely used entropy
+coders, including Huffman, arithmetic coding, the LZ77 family, and the FSE/ANS
+coder inside Zstandard~\cite{rfc8878}, were all designed for \textbf{8-bit byte
+streams}, where there are only 256 possible symbols. Medical images do not fit
+that assumption: a 16-bit pixel has up to 65,536 possible values.
 
-When an 8-bit coder meets 16-bit data, it has two bad options:
+When an 8-bit coder is applied to 16-bit data, it has two poor options:
 
 \begin{enumerate}
   \item \textbf{Split each pixel into a high byte and a low byte} and code them
-  separately. This doubles the number of coding steps and, worse, throws
-  away the relationship between the two bytes.
+  separately. This doubles the number of coding steps and, more importantly,
+  discards the relationship between the two bytes.
   \item \textbf{Cap the alphabet at 256 values} and store anything rarer as raw
   data, which wastes space.
 \end{enumerate}
@@ -118,17 +119,18 @@ When an 8-bit coder meets 16-bit data, it has two bad options:
 Why does splitting hurt? Consider a tiny prediction error like $-2$, $-1$, 0,
 or $+1$. The low byte carries the real information, but the high byte is
 almost always the same (just a sign-extension). A byte-by-byte coder still
-spends bits encoding that high byte even though it's nearly fully
+spends bits encoding that high byte even though it is nearly fully
 determined by the low one. On the test images, the information shared
-between the two bytes ranges from 0.3 to 1.1 bits per pixel---that is the
+between the two bytes ranges from 0.3 to 1.1 bits per pixel, which is the
 ceiling on how much a byte-splitting coder is wasting, and MIC's measured
-5--22\% advantage sits comfortably under that ceiling.
+5--22\% advantage falls within that ceiling.
 
 \paragraph{The residual stream} Throughout, a \emph{residual} is the
 difference between a pixel and a prediction of it. Example: if the predictor
 guesses 1020 and the true pixel is 1023, the residual is $+3$. Smooth regions
-of an image produce lots of residuals near zero, and the same small values show
-up again and again---exactly the pattern run-length and entropy coding love.
+of an image produce many residuals near zero, and the same small values recur
+frequently, which is exactly the pattern run-length and entropy coding exploit
+well.
 
 \subsection{What MIC is}
 
@@ -142,7 +144,7 @@ once.
 
 \begin{itemize}
   \item A \textbf{16-bit-native pipeline} (Delta + 16-bit RLE + extended FSE)
-  that beats Delta + Zstandard on every one of the 21 images.
+  that outperforms Delta + Zstandard on every one of the 21 images.
   \item An \textbf{entropy coder for large alphabets}---up to 65,535 symbols,
   versus the 4,096-symbol limit in Zstandard's FSE. Tables shrink
   automatically to fit the data (as small as ${\sim}2$\,KB for 8-bit content).
@@ -158,35 +160,36 @@ only. Color and multi-frame extensions, lossy modes, and progressive decoding
 are out of scope.
 
 % ============================================================
-\section{Related Work, in One Page}
+\section{Related Work}
 \label{sec:related}
 
 \textbf{The DICOM lossless codecs.} JPEG~2000~\cite{taubman2002} uses a wavelet
-transform plus a sophisticated block coder (EBCOT)---great ratios, slow decode.
-HTJ2K~\cite{htj2k2019,taubman2022} swaps in a faster block coder and decodes
-much quicker. JPEG-LS~\cite{loco1} uses a small predictor (Median Edge
-Detector) and Golomb-Rice coding; it's a widely deployed standard and a strong
-ratio baseline. The basic DICOM run-length scheme barely compresses because it
-works on raw bytes with no prediction step. Research codecs like
-CALIC~\cite{wu1997} and FLIF~\cite{sneyers2016} compress well on natural images
-but aren't DICOM standards and lack browser decoders.
+transform plus a sophisticated block coder (EBCOT): strong ratios, but slow
+decoding. HTJ2K~\cite{htj2k2019,taubman2022} replaces the block coder with a
+faster one and decodes considerably quicker. JPEG-LS~\cite{loco1} uses a small
+predictor (Median Edge Detector) and Golomb-Rice coding; it is a widely
+deployed standard and a strong ratio baseline. The basic DICOM run-length
+scheme compresses little because it works on raw bytes with no prediction step.
+Research codecs such as CALIC~\cite{wu1997} and FLIF~\cite{sneyers2016}
+compress well on natural images but are not DICOM standards and lack browser
+decoders.
 
-These are the codecs MIC is measured against. The goal isn't to dethrone
-them, but to explore a \textbf{simpler, residual-domain design} aimed squarely
-at high-bit-depth images, with strong speed and easy deployment.
+These are the codecs MIC is measured against. The goal is not to outperform
+them on every metric, but to explore a \textbf{simpler, residual-domain design}
+aimed at high-bit-depth images, with strong speed and easy deployment.
 
 \textbf{Entropy coding background.} Asymmetric Numeral Systems
 (ANS)~\cite{duda2009,duda2013} is a family of entropy coders that replaces
 arithmetic coding's interval math with simple integer state updates. FSE is a
 fast, table-driven version of ANS~\cite{fse} made popular by
-Zstandard~\cite{rfc8878}. The catch: these implementations are tuned for byte
-streams (Zstandard caps FSE at 4,096 symbols).
+Zstandard~\cite{rfc8878}. The limitation is that these implementations are
+tuned for byte streams (Zstandard caps FSE at 4,096 symbols).
 
-\textbf{Parallel ANS.} Prior work has shown ANS decoders go faster when you run
-several independent streams at once (Giesen on interleaved
+\textbf{Parallel ANS.} Prior work has shown that ANS decoders run faster when
+several independent streams are decoded at once (Giesen on interleaved
 coders~\cite{giesen2014}; later work scaling this to many
-streams~\cite{lin2023} and to GPUs~\cite{weissenberger2019}). MIC doesn't claim
-to invent ANS or interleaving---it applies these known ideas inside a
+streams~\cite{lin2023} and to GPUs~\cite{weissenberger2019}). MIC does not claim
+to invent ANS or interleaving; it applies these known ideas inside a
 16-bit-native medical codec with a specific large-alphabet design.
 
 Table~\ref{tab:positioning} places MIC against the prior work across five
@@ -227,7 +230,7 @@ The pipeline is three stages, each simple enough to decode in one
 straight-line pass with very few branches: raw 16-bit pixels go through
 spatial prediction (subtract a guess based on neighbors), then 16-bit
 run-length encoding (collapse repeated values), then FSE entropy coding
-(squeeze out the remaining redundancy), producing compressed bytes.
+(remove the remaining redundancy), producing compressed bytes.
 
 \subsection{Spatial prediction}
 
@@ -237,15 +240,15 @@ residual). Pixels on the top edge or left edge use whatever single neighbor is
 available; the very first pixel is stored as-is. Division rounds down, and
 the decoder repeats the exact same arithmetic so reconstruction is exact.
 
-This predictor was chosen because it's cheap, has almost no branches on the
-decode side, and works well on medical images.
+This predictor was chosen because it is inexpensive, has almost no branches on
+the decode side, and works well on medical images.
 
-\paragraph{Other predictors we tried} We compared four predictors (left-only,
-average, Paeth from PNG~\cite{png}, and MED from JPEG-LS~\cite{loco1}) through
-the full pipeline. MED gave the best ratio (about 1.6\% better than average)
-but decoded 1.5--2$\times$ slower because of its three-way branch and a
+\paragraph{Other predictors we evaluated} We compared four predictors
+(left-only, average, Paeth from PNG~\cite{png}, and MED from JPEG-LS~\cite{loco1})
+through the full pipeline. MED gave the best ratio (about 1.6\% better than
+average) but decoded 1.5--2$\times$ slower because of its three-way branch and a
 diagonal dependency that blocks the fast branch-free loop. The average
-predictor won on consistency and speed, so it's the default.
+predictor was preferred for its consistency and speed, so it is the default.
 Table~\ref{tab:predictor-summary} summarizes the comparison.
 
 \begin{table}[htbp]
@@ -265,18 +268,18 @@ MED (JPEG-LS) & 3.52$\times$ & 16/21 & $+$1.6\% \\
 \end{tabular}
 \end{table}
 
-\subsection{Handling big jumps: overflow coding}
+\subsection{Handling large jumps: overflow coding}
 
 Most residuals are small, but occasionally a pixel jumps far from its
-prediction. Rather than widen the whole stream to 32 bits to handle rare big
+prediction. Rather than widen the whole stream to 32 bits to handle rare large
 values, MIC reserves one special code as a \textbf{delimiter}: small, in-range
 residuals are stored directly as 16-bit codes (with zero mapped to a fixed
 midpoint value); a large, out-of-range residual is stored as the delimiter
 followed by the raw pixel value.
 
-On decode, the reader checks each value: if it's the delimiter, the next
-value is a raw pixel; otherwise it's a normal residual. The ranges are
-designed not to overlap, so there's never any ambiguity. In normal 8--16-bit
+On decode, the reader checks each value: if it is the delimiter, the next
+value is a raw pixel; otherwise it is a normal residual. The ranges are
+designed not to overlap, so there is never any ambiguity. In normal 8--16-bit
 clinical data the overflow path is rare; it exists to guarantee correctness,
 not for the common case. Table~\ref{tab:overflow-map} shows the mapping for a
 representative bit depth.
@@ -315,7 +318,7 @@ automatically.
 \textbf{Why 16-bit RLE matters.} Suppose 1,000 identical 16-bit residuals
 appear in a row. MIC encodes that as just two numbers: a count and the value.
 A \emph{byte}-oriented RLE sees the high and low bytes interleaved, so no
-single byte repeats 1,000 times---it's forced into two interleaved runs or
+single byte repeats 1,000 times, so it is forced into two interleaved runs or
 falls back to literals. Working at 16 bits captures the repetition that
 byte-splitting hides.
 
@@ -330,17 +333,17 @@ one symbol, it looks up the current state in a table; the entry tells it which
 symbol to output, how many bits to read next, and how to compute the next
 state. So each symbol costs \textbf{one table lookup, one bit read, and one
 addition}---no multiplies or divides. (Encoding runs the symbols in reverse
-and builds the bitstream backwards; decoding reads forwards. That reversal
-is just how ANS works.)
+and builds the bitstream backwards; decoding reads forwards. That reversal is
+inherent to how ANS works.)
 
 MIC extends FSE to handle up to \textbf{65,535 symbols} instead of Zstandard's
-4,096, because high-bit-depth residuals genuinely need a big alphabet. It
+4,096, because high-bit-depth residuals genuinely require a large alphabet. It
 also \textbf{sizes its tables to the data}: an 8-bit image stored in 16-bit
 containers (common for MR) shrinks the working tables from ${\sim}512$\,KB down
 to about 2\,KB, which keeps everything in fast cache.
 
 \textbf{Picking the table size automatically.} FSE has a ``tableLog'' knob that
-sets how big and precise the probability table is. MIC picks it based on how
+sets how large and precise the probability table is. MIC selects it based on how
 many distinct values it sees and how much data backs each value: it uses a
 larger table only when there are many active symbols \emph{and} enough data to
 estimate their probabilities reliably (for example, mammography images after
@@ -370,25 +373,25 @@ RG3 & 5.64$\times$ & 5.95$\times$ & 6.08$\times$ & 6.08$\times$ \\
 \end{table}
 
 % ============================================================
-\section{Going Faster: Multi-State Decoding}
+\section{Faster Decoding: Multi-State Decoding}
 \label{sec:multistate}
 
 \subsection{The bottleneck}
 
-A normal single-state ANS decoder has a problem: each symbol depends on the
-one before it. To decode symbol $N$ you need the state produced by symbol
-$N-1$, which means the work can't start early. With a table lookup taking
-roughly 4--5 CPU cycles, the loop is stuck at about one symbol every few
-cycles---even though modern CPUs have 4--6 execution ports sitting mostly
-idle. A single decode chain uses just one of them, leaving ${\sim}75$--83\% of
-the CPU's capacity unused.
+A standard single-state ANS decoder has an inherent limitation: each symbol
+depends on the one before it. To decode symbol $N$ the decoder needs the state
+produced by symbol $N-1$, so the work cannot start early. With a table lookup
+taking roughly 4--5 CPU cycles, the loop is limited to about one symbol every
+few cycles, even though modern CPUs have 4--6 execution ports that remain
+largely idle. A single decode chain uses only one of them, leaving
+${\sim}75$--83\% of the CPU's capacity unused.
 
-\subsection{The fix}
+\subsection{The approach}
 
 MIC runs \textbf{several independent decoders at once} on interleaved
 positions. With 8 chains, chain 0 handles positions $0, 8, 16, \ldots$; chain 1
-handles $1, 9, 17, \ldots$; and so on. The chains share nothing during decoding
----each has its own state and its own stream of lookups---so the CPU's
+handles $1, 9, 17, \ldots$; and so on. The chains share nothing during
+decoding, each has its own state and its own stream of lookups, so the CPU's
 out-of-order engine can keep all of them in flight simultaneously.
 
 On the encoder side, the symbols are split into $N$ interleaved groups, each
@@ -397,17 +400,17 @@ all share one decode table, and each chain's starting state is recorded in
 the header. The decoder just writes each chain's output back to its
 positions.
 
-\subsection{How much it helps}
+\subsection{Measured speedup}
 
 In theory, $N$ chains could be up to $N\times$ faster. In practice the speedup
 is smaller because the chains share some bookkeeping (refilling the bit
 reader), the unrolled loop puts pressure on the instruction cache, and reading
 the compressed data has its own bandwidth limit~\cite{williams2009}. Measured
-on the FSE stage alone: \textbf{4 states} give $+$46\% on ARM64 and $+$8\% on
-AMD64 (vs.\ single state), and \textbf{8 states} a further $+$7\% on ARM64 and
-$+$2\% on AMD64, with \textbf{no change to the compressed file}. ARM64 keeps
-improving as chains double; AMD64 flattens out earlier because its core already
-extracts a lot of parallelism from a single chain on its own.
+on the FSE stage alone, \textbf{4 states} give $+$46\% on ARM64 and $+$8\% on
+AMD64 (relative to single state), and \textbf{8 states} a further $+$7\% on
+ARM64 and $+$2\% on AMD64, with \textbf{no change to the compressed file}.
+ARM64 continues to improve as chains double; AMD64 flattens out earlier because
+its core already extracts substantial parallelism from a single chain.
 Table~\ref{tab:latency} shows the simple latency model against the measured
 ARM64 speedup.
 
@@ -428,7 +431,7 @@ States ($k$) & Amortized latency & Theoretical & Empirical (ARM64) \\
 \end{table}
 
 The decoder signals its mode with a short magic header (a reserved byte
-value that can't be a valid single-state setting), so single-, two-, four-,
+value that cannot be a valid single-state setting), so single-, two-, four-,
 and eight-state files all coexist without confusion. On AMD64 and ARM64 the
 inner loop uses each architecture's native variable-shift instructions; other
 platforms get a pure-Go fallback. Table~\ref{tab:format} summarises the
@@ -458,15 +461,15 @@ Per-chain compressed streams & variable & Concatenated chain payloads. \\
 \end{table}
 
 % ============================================================
-\section{How We Measured It}
+\section{Evaluation Methodology}
 \label{sec:methodology}
 
 \textbf{Dataset.} 21 de-identified DICOM images across nine modalities (CT, MR,
 CR, X-ray, mammography, tomosynthesis, and others), from the public NEMA
 WG-04 sample sets~\cite{nema_wg04} and a public breast-tomosynthesis
-case~\cite{clunie_tomo}. It's a varied set but small relative to a real
-clinical archive---hence ``on this 21-image dataset'' rather than sweeping
-claims. Table~\ref{tab:dataset} lists the images.
+case~\cite{clunie_tomo}. It is a varied set but small relative to a real
+clinical archive, so the results are reported as ``on this 21-image dataset''
+rather than as general claims. Table~\ref{tab:dataset} lists the images.
 
 \begin{table}[htbp]
 \centering
@@ -516,7 +519,7 @@ built with \texttt{-O3}. Each benchmark ran the full image 10 times;
 run-to-run variance stayed under 2\% on ARM64 and 5\% on AMD64.
 
 The ``MIC'' column in the result tables is the fastest available C decoder on
-each platform---the eight-state decoder, with AVX-512 acceleration of the
+each platform: the eight-state decoder, with AVX-512 acceleration of the
 run-length and prediction-reversal stages on AMD64. Both read identical
 compressed bytes; only the vector width differs.
 
@@ -531,12 +534,12 @@ ARM64 machine.
 
 \subsection{Compression ratio}
 
-JPEG-LS gets the smallest files on every image---its context-adaptive
-predictor is hard to beat on pure ratio. But MIC isn't optimizing ratio
-alone; it's after the best balance of ratio, speed, and simplicity. Across
-the dataset MIC averages a \textbf{3.46}$\times$ ratio: about 91\% of JPEG-LS
-(3.82$\times$) and essentially tied with HTJ2K (3.45$\times$), while decoding
-faster than both. Mammography compresses best of all (up to 8.79$\times$)
+JPEG-LS produces the smallest files on every image; its context-adaptive
+predictor is difficult to beat on pure ratio. MIC, however, is not optimizing
+ratio alone; it targets the best balance of ratio, speed, and simplicity.
+Across the dataset MIC averages a \textbf{3.46}$\times$ ratio: about 91\% of
+JPEG-LS (3.82$\times$) and essentially tied with HTJ2K (3.45$\times$), while
+decoding faster than both. Mammography compresses best (up to 8.79$\times$)
 because its smooth tissue produces long near-zero runs.
 Table~\ref{tab:ratios} gives the per-image ratios for all variants.
 
@@ -582,11 +585,12 @@ XA1  & 2.00 & 4.37$\times$ & 5.01$\times$ & 4.94$\times$ & 5.04$\times$ & 5.03$\
 MIC encodes faster than the others on most images, on both platforms,
 because its encoder is a single pass (predict, run-length, table-driven
 entropy code) while HTJ2K and JPEG-LS do more work per pixel. On
-\textbf{ARM64}, MIC wins on all 21 images---roughly 1.9--3.2$\times$ HTJ2K,
+\textbf{ARM64}, MIC is fastest on all 21 images: roughly 1.9--3.2$\times$ HTJ2K,
 3--7$\times$ JPEG-LS, and 35--240$\times$ Delta + Zstandard (whose max-level
-LZ77 search is what makes it so slow). On \textbf{AMD64}, MIC wins on 18 of 21;
-HTJ2K narrowly takes the two biggest mammography slabs and one radiography
-image, because the AMD64 baselines are themselves heavily vectorized.
+LZ77 search accounts for its low throughput). On \textbf{AMD64}, MIC is fastest
+on 18 of 21; HTJ2K narrowly leads on the two largest mammography images and one
+radiography image, because the AMD64 baselines are themselves heavily
+vectorized.
 Table~\ref{tab:enc} gives the per-image encoding throughput.
 
 \begin{table*}[htbp]
@@ -631,24 +635,24 @@ XA1  & \textbf{693}   &  7 & 232 & 152 & \textbf{358} &  4 & 310          &  97 
 
 \subsection{Decoding speed}
 
-This is MIC's strongest result. Its decoder is dominated by that tight FSE
-loop---one lookup, one bit read, one add---with no hard-to-predict branches.
+Decoding is where MIC performs best. Its decoder is dominated by the compact
+FSE loop (one lookup, one bit read, one add) with no hard-to-predict branches.
 HTJ2K and JPEG-LS both have data-dependent branches that cause CPU
-mispredictions. Zstandard is the closest relative (same predictor, also uses
-FSE) but works on bytes, so it pays the 2$\times$ byte-splitting cost on deep
-data. On \textbf{ARM64}, MIC is fastest on 20 of 21 images (Zstandard edges it
-out only on CT, by 1.3\%): roughly 1.5--2.6$\times$ HTJ2K, 1.1--1.7$\times$
+mispredictions. Zstandard is the most comparable codec (same predictor, also
+uses FSE) but works on bytes, so it pays the 2$\times$ byte-splitting cost on
+deep data. On \textbf{ARM64}, MIC is fastest on 20 of 21 images (Zstandard is
+faster only on CT, by 1.3\%): roughly 1.5--2.6$\times$ HTJ2K, 1.1--1.7$\times$
 Zstandard, and 2.0--4.5$\times$ JPEG-LS. On \textbf{AMD64}, MIC is fastest on
-all 21 images, from a hair ahead on mammography up to 1.62$\times$ on X-ray;
-switching from four to eight states (plus the AVX-512 widening of the
-post-entropy stages) was what flipped the few remaining close calls into MIC
+all 21 images, from marginally ahead on mammography up to 1.62$\times$ on
+X-ray; switching from four to eight states (plus the AVX-512 widening of the
+post-entropy stages) is what turned the few remaining close cases into MIC
 wins.
 
-So MIC delivers both \textbf{better ratio than Zstandard on every image} and
-\textbf{faster decode on nearly every image}---the signature of the
-16-bit-native design. JPEG-LS keeps about a 10\% ratio edge, so the real
-choice between them is decode speed versus storage cost. Per-image numbers are
-in Table~\ref{tab:decomp}, and the entropy stage in isolation is in
+MIC therefore delivers both \textbf{a better ratio than Zstandard on every
+image} and \textbf{faster decoding on nearly every image}, which reflects the
+16-bit-native design. JPEG-LS retains about a 10\% ratio advantage, so the
+choice between them comes down to decode speed versus storage cost. Per-image
+numbers are in Table~\ref{tab:decomp}, and the entropy stage in isolation is in
 Table~\ref{tab:fse-combined}.
 
 \begin{table*}[htbp]
@@ -724,18 +728,18 @@ RG1  & 1,786 & 3,492 & 5,412 & 1,198 & 1,717 & 2,104 \\
 
 \subsection{Other MIC variants (for reference)}
 
-The main tables use one MIC column, but the codebase has several variants
-that exist for different deployment needs rather than to compete for the
-fastest number. The \textbf{pure Go} build runs the whole thing in Go with no C
-dependency, at roughly 40--60\% of the C decoder's speed---useful where you
-can't link C (mobile, WebAssembly, locked-down runtimes). The
+The main tables use one MIC column, but the codebase includes several variants
+that exist for different deployment needs rather than to compete on raw speed.
+The \textbf{pure Go} build runs the entire pipeline in Go with no C dependency,
+at roughly 40--60\% of the C decoder's speed; this is useful where C cannot be
+linked (mobile, WebAssembly, locked-down runtimes). The
 \textbf{1/2/4-state decoders} are the same C decoder with fewer chains; they
-exist as baselines for the multi-state comparison. \textbf{Wavelet-based MIC}
-swaps the predictor for a reversible 5/3 wavelet transform~\cite{legall1988}
-feeding the same back end; it is competitive on a couple of images but
-generally slower on this corpus, since smooth medical images don't reward the
-wavelet's extra cost. The eight-state C decoder ends up being both the simplest
-and the fastest configuration on this dataset.
+serve as baselines for the multi-state comparison. \textbf{Wavelet-based MIC}
+replaces the predictor with a reversible 5/3 wavelet transform~\cite{legall1988}
+feeding the same back end; it is competitive on a few images but generally
+slower on this corpus, since smooth medical images do not reward the wavelet's
+additional cost. The eight-state C decoder is both the simplest and the fastest
+configuration on this dataset.
 
 \subsection{Multi-threaded decoding}
 
@@ -743,9 +747,9 @@ MIC can also split an image into horizontal strips and decode them on
 separate threads. This scales nearly linearly up to four threads on both
 platforms and keeps scaling to eight threads on images above ${\sim}5$\,MB,
 hitting \textbf{4--4.6\,GB/s} on the largest mammography images. Small images
-don't benefit---below about half a megabyte, thread setup costs more than it
+do not benefit: below about half a megabyte, thread setup costs more than it
 saves. We report this separately because the other codecs run single-threaded
-in our pipeline, so a head-to-head wouldn't be fair.
+in our pipeline, so a direct comparison would not be fair.
 Table~\ref{tab:pics} gives the per-image strip-parallel numbers.
 
 \begin{table*}[htbp]
@@ -788,19 +792,20 @@ XA1  & 759   & 1{,}214 & 1{,}881 & 3{,}191         & 688   & 792     & 1{,}246 &
 \end{tabular}
 \end{table*}
 
-Practical rule of thumb: decode many small images? Use single-threaded MIC
-per request (already fast). Decode one big image on a multi-core box? Use
-strip-parallel with four to eight threads.
+Practical guidance: to decode many small images, use single-threaded MIC
+per request, which is already fast. To decode one large image on a multi-core
+machine, use strip-parallel mode with four to eight threads.
 
 \subsection{In the browser}
 
-The JavaScript decoder runs well. Interestingly, the \textbf{four-state}
-variant is 7--13\% \emph{faster} than eight-state in JS, even on the same
-hardware where eight states win in C. The reason is the JavaScript engine
+The JavaScript decoder performs well. Notably, the \textbf{four-state}
+variant is 7--13\% \emph{faster} than eight-state in JavaScript, even on the
+same hardware where eight states win in C. The reason is the JavaScript engine
 (V8): it can keep four independent chains busy but not eight, so the extra
-chains just add overhead without shortening the critical path. The eight-state
-path still works in JS---it lets one decoder accept C-encoded files without
-conversion---but four states is the sweet spot for the browser.
+chains add overhead without shortening the critical path. The eight-state
+path still works in JavaScript (it lets one decoder accept C-encoded files
+without conversion), but four states is the best configuration for the
+browser.
 
 Concretely, a 9.35\,MB mammography image decodes in 19.8\,ms (473\,MB/s) using
 eight workers with four-state strips. That means a web DICOM viewer can pull
@@ -857,26 +862,27 @@ MG1 & 8 &  19.8 & 473 &  20.5 & 457 \\
 
 \subsection{Reading the results together}
 
-Three things tie the numbers together. First, MIC's \textbf{ratio edge over
-Zstandard} (5--22\%, 14\% average) comes mainly from working on 16-bit
-residuals directly instead of splitting them into bytes---and that same choice
-removes the per-byte branches that slow decoding. Second, on the very largest
+Three observations tie the numbers together. First, MIC's \textbf{ratio
+advantage over Zstandard} (5--22\%, 14\% average) comes mainly from working on
+16-bit residuals directly instead of splitting them into bytes, and that same
+choice removes the per-byte branches that slow decoding. Second, on the largest
 mammography images on AMD64, \textbf{HTJ2K's block coder} regains the speed
 lead by amortizing its setup over many pixels; MIC stays within 0--20\% there.
 Third, \textbf{multi-state decoding} is what makes MIC's decoder competitive
 with HTJ2K's vectorized block coder, and it costs nothing in file size.
 
-\subsection{Which codec to pick}
+\subsection{Choosing a codec}
 
 For \textbf{low-latency viewing} (PACS, thumbnails, tomosynthesis playback),
-single-threaded MIC is a sensible default (${\sim}600$--900\,MB/s per request);
-strip-parallel MIC for one big image at a time. For \textbf{smallest archival
-files}, JPEG-LS keeps ${\sim}10\%$ better ratio---at the cost of decoding
-1.6--5.7$\times$ slower on ARM64. Where \textbf{DICOM transfer-syntax
-compatibility} is required, HTJ2K is the choice, since it's a standard (and
-it's specifically strong on big mammography on AMD64). Where \textbf{no native
-code is allowed} (browsers, sandboxes), the pure-Go reference or the 20\,KB
-JavaScript decoder runs at about half the C decoder's speed.
+single-threaded MIC is a sensible default (${\sim}600$--900\,MB/s per request),
+with strip-parallel MIC for one large image at a time. For \textbf{smallest
+archival files}, JPEG-LS keeps a ${\sim}10\%$ better ratio, at the cost of
+decoding 1.6--5.7$\times$ slower on ARM64. Where \textbf{DICOM transfer-syntax
+compatibility} is required, HTJ2K is the appropriate choice, since it is a
+standard and is particularly strong on large mammography images on AMD64. Where
+\textbf{no native code is permitted} (browsers, sandboxes), the pure-Go
+reference or the 20\,KB JavaScript decoder runs at about half the C decoder's
+speed.
 
 A more structured comparison---a Pareto view of ratio vs.\ decode
 speed~\cite{geldreich_pareto,jpegxl_pareto}, plus a weighted decision matrix
@@ -884,8 +890,8 @@ over ratio, speed, platform coverage, and deployment
 ease~\cite{saaty_ahp,sayood}, following deployment taxonomies for DICOM
 compression~\cite{clunie_miit2009,liu2017}---puts MIC and JPEG-LS on the
 efficiency frontier (MIC for throughput, JPEG-LS for ratio), with HTJ2K and
-Zstandard dominated on those two axes. HTJ2K still wins whenever standard
-compatibility is a hard requirement that the scoring doesn't capture.
+Zstandard dominated on those two axes. HTJ2K remains the choice whenever
+standard compatibility is a hard requirement that the scoring does not capture.
 Table~\ref{tab:decision-matrix} reports the weighted matrix.
 
 \begin{table}[htbp]


### PR DESCRIPTION
Revise the plain-language edition to keep an accessible but measured,
formal academic tone: replace dramatic and colloquial phrasings (e.g.
"stumble", "chopping", "the catch", "dethrone", "sweet spot",
"rule of thumb", "a hair ahead"), expand contractions, and rename
casual section headers. Also reduce body-text em dashes per the paper
editorial rules. Content, numbers, tables, and references are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0121mzay2mJLdzHGejmdGRqF