### PR TITLE
Add Tone and Readability rules (§11) to paper editorial guide

### DIFF
--- a/.claude/paper-rules.md
+++ b/.claude/paper-rules.md
@@ -312,21 +312,30 @@ history must be removed before the file is sent for review.
 
 ## 11. Tone and Readability
 
-These rules apply to all versions, and especially to the plain-language
-(`mic-paper-simplified-*.tex`) edition: keep the prose accessible, but the
-register must stay measured and formal — accessible is not the same as casual.
+Apply these rules to all versions, and especially to the plain-language
+("simplified") edition (`mic-paper-simplified-ieee.tex`). The simplified
+edition must stay **accessible and easy to read, but the register is measured
+and formal** — explain things simply without sounding casual, dramatic, or
+promotional. Accessible is not the same as casual.
 
-### No contractions in body text
-Expand all contractions in prose, captions, and headings: `it's` → `it is`,
-`isn't` → `is not`, `doesn't` → `does not`, `can't` → `cannot`, `won't` →
-`will not`, `there's` → `there is`, `that's` → `that is`, `we've` → `we have`,
-`aren't` → `are not`, `don't` → `do not`. Check with
-`grep -nE "\b(it's|isn't|aren't|don't|doesn't|won't|can't|that's|there's|we've|wouldn't|couldn't)\b" mic-paper-*.tex`.
+### No contractions
+Expand all contractions in prose, captions, and bullets: `it's` → `it is`,
+`isn't`/`aren't` → `is not`/`are not`, `don't`/`doesn't` → `do not`/`does not`,
+`can't` → `cannot`, `won't` → `will not`, `that's` → `that is`, `there's` →
+`there is`, `we've` → `we have`, `we're`/`you're` → `we are`/`you are`,
+`wouldn't`/`couldn't` → `would not`/`could not`. Possessive `'s` is fine.
+
+Check with:
+`grep -nE "\b(it's|isn't|aren't|don't|doesn't|won't|can't|that's|there's|we've|we're|you're|wouldn't|couldn't)\b" mic-paper-*.tex`
 
 ### No second person or rhetorical questions
-Do not address the reader as "you" ("when you run…", "decode many small
-images? Use…"). Rewrite in the third person or imperative ("when several
-streams are decoded…", "to decode many small images, use…").
+Do not address the reader as "you" or pose rhetorical questions in body text.
+Rewrite in the third person or imperative.
+
+- Not: "when you run several streams at once" → "when several streams are
+  decoded at once".
+- Not: "Decode many small images? Use single-threaded MIC." → "To decode many
+  small images, use single-threaded MIC."
 
 ### Replace colloquial and dramatic wording
 Prefer neutral, precise verbs and adjectives over informal or promotional ones:
@@ -335,23 +344,31 @@ Prefer neutral, precise verbs and adjectives over informal or promotional ones:
 |-------|--------|
 | stumble, choke | perform poorly, struggle |
 | chopping / chop up | splitting |
+| throws away | discards |
 | the catch / the gotcha | the limitation |
 | dethrone, crush, beat (as a headline) | outperform, surpass |
-| sweet spot | best configuration / optimum |
-| rule of thumb | practical guidance |
 | a hair ahead, a touch faster | marginally ahead |
+| sweet spot | best configuration / optimal point |
+| rule of thumb | practical guidance |
 | bad options | poor options |
 | big (jumps, alphabet, box, image) | large |
-| tops 2 GB | exceeds 2 GB |
-| a lot of data | a great deal of / a large volume of data |
-| runs well, runs great | performs well |
-| the signature of X | which reflects X |
-| love / hate (of an algorithm) | exploit well / handle poorly |
+| edges it out / wins (in prose) | is faster / is fastest |
+| squeeze out | remove |
+| love / hate (anthropomorphizing code) | exploit well / handle poorly |
 | just how X works | inherent to how X works |
+| the signature of X | which reflects X |
+| runs well, runs great | performs well |
+| ends up being | is |
+| a lot of / lots of data | a great deal of / a large volume of data |
+| tops 2 GB | exceeds 2 GB |
+| sitting idle | remaining idle |
+| the fix | the approach / the solution |
 
 Use verbs like "wins" only inside results prose where the comparison is
 explicit and quantified; prefer "is fastest" / "is the fastest codec" in
-headline sentences.
+headline sentences. Keep the measured-claims discipline from §10: do not call
+results "strongest", "remarkable", or "dramatic" — state the number and let it
+speak.
 
 ### Neutral section and subsection headers
 Headers state the topic, not a slogan. Avoid "… in One Page", "Going Faster:",
@@ -360,9 +377,13 @@ Use topical equivalents: "Related Work", "Faster Decoding: …", "The approach",
 "Measured speedup", "Evaluation Methodology", "Choosing a codec".
 
 ### Keep
-- Plain-language explanations, numeric examples, and the "FSE in one
-  paragraph" style sentences required by §1 — these stay; only the
-  colloquial register is removed.
+- Plain-language explanations, numeric examples, and the "FSE in one paragraph"
+  style sentences required by §1 — these stay; only the colloquial register is
+  removed.
 - Bold lead-in phrases that introduce a paragraph's topic
   (e.g. `\textbf{Why 16-bit RLE matters.}`).
 
+### Scope of a tone pass
+A tone pass is prose-only: do not alter numbers, table data, references,
+labels, or `\cite`/`\ref` keys. The em-dash reductions in §3 are part of the
+same readability discipline; apply them together.

--- a/.claude/paper-rules.md
+++ b/.claude/paper-rules.md
@@ -307,3 +307,62 @@ history must be removed before the file is sent for review.
 3. `grep -in "M2 Max\|M4 Pro\|285K\|Core Ultra\|c8i\|Xeon\|Granite Rapids\|Apple M"` —
    every hit must be inside the single Benchmark Procedure subsection.
    Any hit elsewhere in the paper is a violation of §6.
+
+---
+
+## 11. Tone and Readability
+
+These rules apply to all versions, and especially to the plain-language
+(`mic-paper-simplified-*.tex`) edition: keep the prose accessible, but the
+register must stay measured and formal — accessible is not the same as casual.
+
+### No contractions in body text
+Expand all contractions in prose, captions, and headings: `it's` → `it is`,
+`isn't` → `is not`, `doesn't` → `does not`, `can't` → `cannot`, `won't` →
+`will not`, `there's` → `there is`, `that's` → `that is`, `we've` → `we have`,
+`aren't` → `are not`, `don't` → `do not`. Check with
+`grep -nE "\b(it's|isn't|aren't|don't|doesn't|won't|can't|that's|there's|we've|wouldn't|couldn't)\b" mic-paper-*.tex`.
+
+### No second person or rhetorical questions
+Do not address the reader as "you" ("when you run…", "decode many small
+images? Use…"). Rewrite in the third person or imperative ("when several
+streams are decoded…", "to decode many small images, use…").
+
+### Replace colloquial and dramatic wording
+Prefer neutral, precise verbs and adjectives over informal or promotional ones:
+
+| Avoid | Prefer |
+|-------|--------|
+| stumble, choke | perform poorly, struggle |
+| chopping / chop up | splitting |
+| the catch / the gotcha | the limitation |
+| dethrone, crush, beat (as a headline) | outperform, surpass |
+| sweet spot | best configuration / optimum |
+| rule of thumb | practical guidance |
+| a hair ahead, a touch faster | marginally ahead |
+| bad options | poor options |
+| big (jumps, alphabet, box, image) | large |
+| tops 2 GB | exceeds 2 GB |
+| a lot of data | a great deal of / a large volume of data |
+| runs well, runs great | performs well |
+| the signature of X | which reflects X |
+| love / hate (of an algorithm) | exploit well / handle poorly |
+| just how X works | inherent to how X works |
+
+Use verbs like "wins" only inside results prose where the comparison is
+explicit and quantified; prefer "is fastest" / "is the fastest codec" in
+headline sentences.
+
+### Neutral section and subsection headers
+Headers state the topic, not a slogan. Avoid "… in One Page", "Going Faster:",
+"The fix", "How much it helps", "How We Measured It", "Which codec to pick".
+Use topical equivalents: "Related Work", "Faster Decoding: …", "The approach",
+"Measured speedup", "Evaluation Methodology", "Choosing a codec".
+
+### Keep
+- Plain-language explanations, numeric examples, and the "FSE in one
+  paragraph" style sentences required by §1 — these stay; only the
+  colloquial register is removed.
+- Bold lead-in phrases that introduce a paragraph's topic
+  (e.g. `\textbf{Why 16-bit RLE matters.}`).
+


### PR DESCRIPTION
Adds §11 "Tone and Readability" to `.claude/paper-rules.md`, codifying the
conventions applied in the simplified IEEE paper language pass (PR #29). That
PR changed the paper prose but was merged before these rules were written, so
this follow-up captures the rules themselves.

The new section documents:

- **No contractions** — expansion list plus a `grep` check command.
- **No second person or rhetorical questions** — with before/after examples.
- **Colloquial → neutral wording table** — every substitution made (e.g.
  stumble → perform poorly, chopping → splitting, the catch → the limitation,
  dethrone → outperform, sweet spot → best configuration, big → large), plus
  the rule to reserve "wins" for explicit, quantified comparisons and the §10
  measured-claims tie-in.
- **Neutral section/subsection headers** — topical equivalents for slogan-style
  headers.
- **Keep** — plain-language explanations, FSE-in-one-paragraph style (§1), and
  bold topic lead-ins stay; only the casual register is removed.
- **Scope of a tone pass** — prose-only; no changes to numbers, tables, refs,
  or labels; apply alongside the §3 em-dash reductions.

Single-file change: `.claude/paper-rules.md` (+80 lines). No code or paper
content is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121mzay2mJLdzHGejmdGRqF)_