### PR TITLE
Update simplified IEEE paper to 39-image / eleven-modality benchmarks

### DIFF
--- a/paper/mic-paper-simplified-ieee.tex
+++ b/paper/mic-paper-simplified-ieee.tex
@@ -62,15 +62,15 @@ pixel into two bytes. MIC chains three simple stages, a spatial predictor, a
 16-bit run-length encoder, and a large-alphabet entropy coder called Finite
 State Entropy (FSE, a fast table-driven form of asymmetric numeral systems),
 and adds a multi-state decoder that keeps the CPU more fully utilized to speed
-up decompression. On 21 real DICOM images across nine modalities, MIC compresses
-5--22\% better (14\% on average) than a strong general-purpose baseline
-(Delta\,+\,Zstandard), reaches an average compression ratio of
-3.46$\times$ (essentially tied with High-Throughput JPEG~2000 at 3.45$\times$
-and about 91\% of JPEG-LS at 3.82$\times$), and is the fastest decoder of the
-four tested codecs on 20 of 21 images on ARM64 and all 21 on AMD64. A 20\,KB
-pure-JavaScript decoder lets the format be decoded directly in a web browser.
-The main caveat is that this is a 21-image study; the results are encouraging
-but need confirmation on larger, multi-hospital datasets.
+up decompression. On 39 real DICOM images across eleven modalities, MIC
+compresses about 10\% better on average (better on 34 of the 39 images) than a
+strong general-purpose baseline (Delta\,+\,Zstandard), reaches a geometric-mean
+compression ratio of 3.36$\times$ (within about 2\% of High-Throughput
+JPEG~2000 at 3.42$\times$ and about 88\% of JPEG-LS at 3.84$\times$), and is the
+fastest decoder of the four tested codecs on all 39 images on ARM64 and 36 of 39
+on AMD64. A 20\,KB pure-JavaScript decoder lets the format be decoded directly
+in a web browser. The main caveat is that this is a 39-image study; the results
+are encouraging but need confirmation on larger, multi-hospital datasets.
 \end{abstract}
 
 \begin{IEEEkeywords}
@@ -144,7 +144,8 @@ once.
 
 \begin{itemize}
   \item A \textbf{16-bit-native pipeline} (Delta + 16-bit RLE + extended FSE)
-  that outperforms Delta + Zstandard on every one of the 21 images.
+  that outperforms Delta + Zstandard on the large majority of images (34 of 39,
+  by about 10\% in geometric mean).
   \item An \textbf{entropy coder for large alphabets}---up to 65,535 symbols,
   versus the 4,096-symbol limit in Zstandard's FSE. Tables shrink
   automatically to fit the data (as small as ${\sim}2$\,KB for 8-bit content).
@@ -245,7 +246,7 @@ the decode side, and works well on medical images.
 
 \paragraph{Other predictors we evaluated} We compared four predictors
 (left-only, average, Paeth from PNG~\cite{png}, and MED from JPEG-LS~\cite{loco1})
-through the full pipeline. MED gave the best ratio (about 1.6\% better than
+through the full pipeline. MED gave the best ratio (about 2.4\% better than
 average) but decoded 1.5--2$\times$ slower because of its three-way branch and a
 diagonal dependency that blocks the fast branch-free loop. The average
 predictor was preferred for its consistency and speed, so it is the default.
@@ -254,16 +255,16 @@ Table~\ref{tab:predictor-summary} summarizes the comparison.
 \begin{table}[htbp]
 \centering
 \caption{Predictor ablation summary: geometric means and win counts across all
-21 images.}
+39 images.}
 \label{tab:predictor-summary}
 \begin{tabular}{lrrr}
 \toprule
 Predictor & Geo.\ Mean & Wins & Avg$\to$X \\
 \midrule
-Left-only & 3.38$\times$ & 3/21 & $-$2.3\% \\
-Average (MIC) & 3.46$\times$ & 13/21 & baseline \\
-Paeth & 3.48$\times$ & 2/21 & $+$0.5\% \\
-MED (JPEG-LS) & 3.52$\times$ & 16/21 & $+$1.6\% \\
+Left-only & 3.22$\times$ & 2/39 & $-$4.4\% \\
+Average (MIC) & 3.36$\times$ & 11/39 & baseline \\
+Paeth & 3.39$\times$ & 0/39 & $+$0.8\% \\
+MED (JPEG-LS) & 3.44$\times$ & 26/39 & $+$2.4\% \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -406,9 +407,9 @@ In theory, $N$ chains could be up to $N\times$ faster. In practice the speedup
 is smaller because the chains share some bookkeeping (refilling the bit
 reader), the unrolled loop puts pressure on the instruction cache, and reading
 the compressed data has its own bandwidth limit~\cite{williams2009}. Measured
-on the FSE stage alone, \textbf{4 states} give $+$46\% on ARM64 and $+$8\% on
-AMD64 (relative to single state), and \textbf{8 states} a further $+$7\% on
-ARM64 and $+$2\% on AMD64, with \textbf{no change to the compressed file}.
+on the FSE stage alone, \textbf{4 states} give $+$36\% on ARM64 and $+$12\% on
+AMD64 (relative to single state), and \textbf{8 states} a further $+$5\% on
+ARM64 and $+$1\% on AMD64, with \textbf{no change to the compressed file}.
 ARM64 continues to improve as chains double; AMD64 flattens out earlier because
 its core already extracts substantial parallelism from a single chain.
 Table~\ref{tab:latency} shows the simple latency model against the measured
@@ -464,16 +465,19 @@ Per-chain compressed streams & variable & Concatenated chain payloads. \\
 \section{Evaluation Methodology}
 \label{sec:methodology}
 
-\textbf{Dataset.} 21 de-identified DICOM images across nine modalities (CT, MR,
-CR, X-ray, mammography, tomosynthesis, and others), from the public NEMA
-WG-04 sample sets~\cite{nema_wg04} and a public breast-tomosynthesis
-case~\cite{clunie_tomo}. It is a varied set but small relative to a real
-clinical archive, so the results are reported as ``on this 21-image dataset''
-rather than as general claims. Table~\ref{tab:dataset} lists the images.
+\textbf{Dataset.} 39 de-identified DICOM images across eleven modalities (CT,
+MR, CR, X-ray, mammography, digital radiography, nuclear medicine, PET,
+fluoroscopy, secondary capture, and tomosynthesis), drawn from the public NEMA
+WG-04 sample sets~\cite{nema_wg04}, the NEMA 1997 CD, a public
+breast-tomosynthesis case~\cite{clunie_tomo}, and additional grayscale slices
+from public GDCM and TCIA collections. It is a varied set but small relative to
+a real clinical archive, so the results are reported as ``on this 39-image
+dataset'' rather than as general claims. Table~\ref{tab:dataset} lists the
+images.
 
 \begin{table}[htbp]
 \centering
-\caption{Test dataset: 21 clinical DICOM images spanning nine modalities.}
+\caption{Test dataset: 39 clinical DICOM images spanning eleven modalities.}
 \label{tab:dataset}
 \scriptsize
 \begin{tabular}{llrr}
@@ -501,6 +505,24 @@ RG2  & Radiography    & $1760{\times}2140$ & 7.18 \\
 RG3  & Radiography    & $1760{\times}1760$ & 5.91 \\
 SC1  & Sec.~capture   & $2048{\times}2487$ & 9.71 \\
 XA1  & Fluoroscopy    & $1024{\times}1024$ & 2.00 \\
+CT\_BRAIN    & CT scan             & $512{\times}512$   & 0.50 \\
+CT\_ANKLE    & CT scan             & $512{\times}512$   & 0.50 \\
+CT\_ORT      & CT scan             & $512{\times}512$   & 0.50 \\
+CT\_CHEST    & CT scan             & $400{\times}512$   & 0.39 \\
+MR\_HEAD     & Brain MRI           & $256{\times}256$   & 0.13 \\
+MR\_INTERA   & Brain MRI           & $1024{\times}1024$ & 2.00 \\
+DX\_HAND     & Digital radiography & $1480{\times}1410$ & 3.98 \\
+DX\_CHEST    & Digital radiography & $1416{\times}1420$ & 3.84 \\
+CR\_THORAX   & Comp.\ radiography  & $2076{\times}1876$ & 7.43 \\
+PET1         & PET                 & $256{\times}256$   & 0.13 \\
+PET2         & PET                 & $256{\times}256$   & 0.13 \\
+CT\_LUNG     & CT scan             & $512{\times}512$   & 0.50 \\
+CT\_PANCREAS & CT scan             & $512{\times}512$   & 0.50 \\
+MR\_BRAIN    & Brain MRI           & $320{\times}256$   & 0.16 \\
+MR\_BREAST   & Breast MRI          & $256{\times}256$   & 0.13 \\
+MR\_PROSTATE & Prostate MRI        & $320{\times}320$   & 0.20 \\
+PET\_PSMA    & PET                 & $200{\times}200$   & 0.08 \\
+PET\_LUNG    & PET                 & $200{\times}200$   & 0.08 \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -534,18 +556,20 @@ ARM64 machine.
 
 \subsection{Compression ratio}
 
-JPEG-LS produces the smallest files on every image; its context-adaptive
-predictor is difficult to beat on pure ratio. MIC, however, is not optimizing
-ratio alone; it targets the best balance of ratio, speed, and simplicity.
-Across the dataset MIC averages a \textbf{3.46}$\times$ ratio: about 91\% of
-JPEG-LS (3.82$\times$) and essentially tied with HTJ2K (3.45$\times$), while
-decoding faster than both. Mammography compresses best (up to 8.79$\times$)
-because its smooth tissue produces long near-zero runs.
+JPEG-LS produces the smallest files on nearly every image (37 of 39); its
+context-adaptive predictor is difficult to beat on pure ratio. MIC, however, is
+not optimizing ratio alone; it targets the best balance of ratio, speed, and
+simplicity. Across the dataset MIC reaches a \textbf{3.36}$\times$
+geometric-mean ratio: about 88\% of JPEG-LS (3.84$\times$) and within about 2\%
+of HTJ2K (3.42$\times$), while decoding faster than both. Mammography compresses
+best (up to 8.79$\times$) because its smooth tissue produces long near-zero
+runs, and studies with large uniform backgrounds reach the highest single-image
+ratios (PET\_PSMA at 10.12$\times$, CT\_ANKLE at 9.48$\times$).
 Table~\ref{tab:ratios} gives the per-image ratios for all variants.
 
 \begin{table*}[t]
 \centering
-\caption{Lossless compression ratios: all codec variants, 21 images. Bold =
+\caption{Lossless compression ratios: all codec variants, 39 images. Bold =
 best ratio per row.}
 \label{tab:ratios}
 \scriptsize
@@ -553,29 +577,47 @@ best ratio per row.}
 \toprule
 Image & Raw (MB) & $\Delta$+Zstd-19 & MIC & Wavelet & PICS-4 & PICS-8 & HTJ2K & JPEG-LS \\
 \midrule
-MR   & 0.13 & 1.95$\times$ & 2.35$\times$ & 2.38$\times$ & 2.28$\times$ & 2.21$\times$ & 2.38$\times$ & \textbf{2.52$\times$} \\
-CT   & 0.50 & 2.05$\times$ & 2.24$\times$ & 1.67$\times$ & 2.15$\times$ & 1.96$\times$ & 1.77$\times$ & \textbf{2.68$\times$} \\
-CR   & 7.18 & 3.24$\times$ & 3.69$\times$ & 3.81$\times$ & 3.70$\times$ & 3.71$\times$ & 3.77$\times$ & \textbf{3.96$\times$} \\
-XR   & 10.1 & 1.43$\times$ & 1.74$\times$ & \textbf{1.76$\times$} & 1.75$\times$ & \textbf{1.76$\times$} & 1.67$\times$ & \textbf{1.76$\times$} \\
-MG1  & 9.35 & 7.20$\times$ & 8.79$\times$ & 8.67$\times$ & 8.84$\times$ & 8.87$\times$ & 8.25$\times$ & \textbf{8.91$\times$} \\
-MG2  & 9.35 & 7.21$\times$ & 8.77$\times$ & 8.65$\times$ & 8.83$\times$ & 8.85$\times$ & 8.24$\times$ & \textbf{8.90$\times$} \\
-MG3  & 27.3 & 2.04$\times$ & 2.24$\times$ & 2.32$\times$ & 2.31$\times$ & 2.34$\times$ & 2.22$\times$ & \textbf{2.38$\times$} \\
-MG4  & 26.0 & 3.10$\times$ & 3.47$\times$ & 3.59$\times$ & 3.59$\times$ & 3.62$\times$ & 3.51$\times$ & \textbf{3.71$\times$} \\
-CT1  & 0.50 & 2.47$\times$ & 2.79$\times$ & 2.49$\times$ & 2.54$\times$ & 2.29$\times$ & 2.70$\times$ & \textbf{3.19$\times$} \\
-CT2  & 0.50 & 3.24$\times$ & 3.49$\times$ & 2.87$\times$ & 3.11$\times$ & 2.72$\times$ & 3.29$\times$ & \textbf{4.54$\times$} \\
-MG-N & 27.3 & 2.04$\times$ & 2.24$\times$ & 2.32$\times$ & 2.31$\times$ & 2.34$\times$ & 2.23$\times$ & \textbf{2.38$\times$} \\
-MR1  & 0.50 & 1.79$\times$ & 2.09$\times$ & 2.14$\times$ & 2.10$\times$ & 2.08$\times$ & 2.13$\times$ & \textbf{2.30$\times$} \\
-MR2  & 2.00 & 2.77$\times$ & 3.28$\times$ & 3.34$\times$ & 3.31$\times$ & 3.31$\times$ & 3.35$\times$ & \textbf{3.52$\times$} \\
-MR3  & 0.50 & 3.47$\times$ & 3.93$\times$ & 4.09$\times$ & 3.89$\times$ & 3.84$\times$ & 4.33$\times$ & \textbf{4.51$\times$} \\
-MR4  & 0.50 & 3.58$\times$ & 4.12$\times$ & 4.18$\times$ & 4.09$\times$ & 4.03$\times$ & 4.21$\times$ & \textbf{4.49$\times$} \\
-NM1  & 0.50 & 4.88$\times$ & 5.15$\times$ & 5.02$\times$ & 5.26$\times$ & 5.28$\times$ & 5.76$\times$ & \textbf{6.28$\times$} \\
-RG1  & 6.86 & 1.45$\times$ & 1.70$\times$ & 1.70$\times$ & 1.70$\times$ & 1.69$\times$ & 1.63$\times$ & \textbf{1.72$\times$} \\
-RG2  & 7.18 & 3.68$\times$ & 4.23$\times$ & 4.32$\times$ & 4.28$\times$ & 4.30$\times$ & 4.32$\times$ & \textbf{4.51$\times$} \\
-RG3  & 5.91 & 5.46$\times$ & 6.08$\times$ & 6.82$\times$ & 6.11$\times$ & 6.12$\times$ & 6.99$\times$ & \textbf{7.31$\times$} \\
-SC1  & 9.71 & 3.46$\times$ & 3.71$\times$ & 3.70$\times$ & 3.73$\times$ & 3.74$\times$ & 3.85$\times$ & \textbf{4.73$\times$} \\
-XA1  & 2.00 & 4.37$\times$ & 5.01$\times$ & 4.94$\times$ & 5.04$\times$ & 5.03$\times$ & 4.88$\times$ & \textbf{5.39$\times$} \\
+MR             & 0.13 & 1.95$\times$ & 2.35$\times$ & 2.38$\times$ & 2.28$\times$ & 2.21$\times$ & 2.38$\times$ & \textbf{2.52$\times$} \\
+CT             & 0.50 & 2.05$\times$ & 2.24$\times$ & 1.67$\times$ & 2.15$\times$ & 1.96$\times$ & 1.77$\times$ & \textbf{2.68$\times$} \\
+CR             & 7.18 & 3.24$\times$ & 3.69$\times$ & 3.81$\times$ & 3.70$\times$ & 3.71$\times$ & 3.77$\times$ & \textbf{3.96$\times$} \\
+XR             & 10.1 & 1.43$\times$ & 1.74$\times$ & \textbf{1.76$\times$} & 1.75$\times$ & 1.75$\times$ & 1.67$\times$ & \textbf{1.76$\times$} \\
+MG1            & 9.35 & 7.20$\times$ & 8.79$\times$ & 8.66$\times$ & 8.84$\times$ & 8.87$\times$ & 8.25$\times$ & \textbf{8.91$\times$} \\
+MG2            & 9.35 & 7.21$\times$ & 8.77$\times$ & 8.65$\times$ & 8.83$\times$ & 8.85$\times$ & 8.24$\times$ & \textbf{8.90$\times$} \\
+MG3            & 27.3 & 2.09$\times$ & 2.24$\times$ & 2.31$\times$ & 2.31$\times$ & 2.33$\times$ & 2.22$\times$ & \textbf{2.38$\times$} \\
+MG4            & 26.0 & 3.10$\times$ & 3.47$\times$ & 3.59$\times$ & 3.58$\times$ & 3.62$\times$ & 3.51$\times$ & \textbf{3.71$\times$} \\
+CT1            & 0.50 & 2.47$\times$ & 2.79$\times$ & 2.48$\times$ & 2.54$\times$ & 2.29$\times$ & 2.70$\times$ & \textbf{3.19$\times$} \\
+CT2            & 0.50 & 3.24$\times$ & 3.48$\times$ & 2.87$\times$ & 3.11$\times$ & 2.72$\times$ & 3.29$\times$ & \textbf{4.54$\times$} \\
+MG-N           & 27.3 & 2.04$\times$ & 2.24$\times$ & 2.32$\times$ & 2.31$\times$ & 2.34$\times$ & 2.23$\times$ & \textbf{2.38$\times$} \\
+MR1            & 0.50 & 1.79$\times$ & 2.09$\times$ & 2.14$\times$ & 2.10$\times$ & 2.08$\times$ & 2.12$\times$ & \textbf{2.30$\times$} \\
+MR2            & 2.00 & 2.77$\times$ & 3.28$\times$ & 3.34$\times$ & 3.31$\times$ & 3.31$\times$ & 3.35$\times$ & \textbf{3.52$\times$} \\
+MR3            & 0.50 & 3.47$\times$ & 3.92$\times$ & 4.09$\times$ & 3.89$\times$ & 3.83$\times$ & 4.33$\times$ & \textbf{4.51$\times$} \\
+MR4            & 0.50 & 3.58$\times$ & 4.12$\times$ & 4.18$\times$ & 4.09$\times$ & 4.03$\times$ & 4.21$\times$ & \textbf{4.49$\times$} \\
+NM1            & 0.50 & 4.88$\times$ & 5.15$\times$ & 5.01$\times$ & 5.25$\times$ & 5.28$\times$ & 5.76$\times$ & \textbf{6.28$\times$} \\
+RG1            & 6.86 & 1.45$\times$ & 1.70$\times$ & 1.70$\times$ & 1.70$\times$ & 1.69$\times$ & 1.63$\times$ & \textbf{1.72$\times$} \\
+RG2            & 7.18 & 3.69$\times$ & 4.23$\times$ & 4.32$\times$ & 4.28$\times$ & 4.30$\times$ & 4.32$\times$ & \textbf{4.51$\times$} \\
+RG3            & 5.91 & 5.46$\times$ & 6.08$\times$ & 6.82$\times$ & 6.11$\times$ & 6.12$\times$ & 6.99$\times$ & \textbf{7.31$\times$} \\
+SC1            & 9.71 & 3.46$\times$ & 3.71$\times$ & 3.70$\times$ & 3.73$\times$ & 3.73$\times$ & 3.85$\times$ & \textbf{4.73$\times$} \\
+XA1            & 2.00 & 4.37$\times$ & 5.01$\times$ & 4.94$\times$ & 5.04$\times$ & 5.03$\times$ & 4.88$\times$ & \textbf{5.39$\times$} \\
+CT\_BRAIN      & 0.50 & 3.08$\times$ & 3.06$\times$ & 2.89$\times$ & 2.77$\times$ & 2.47$\times$ & 3.39$\times$ & \textbf{4.28$\times$} \\
+CT\_ANKLE      & 0.50 & 9.30$\times$ & \textbf{9.48$\times$} & 5.02$\times$ & 9.30$\times$ & 9.14$\times$ & 4.97$\times$ & 6.87$\times$ \\
+CT\_ORT        & 0.50 & 2.36$\times$ & 2.68$\times$ & 2.38$\times$ & 2.51$\times$ & 2.26$\times$ & 2.56$\times$ & \textbf{3.00$\times$} \\
+CT\_CHEST      & 0.39 & 2.46$\times$ & 2.82$\times$ & 2.10$\times$ & 2.52$\times$ & 2.21$\times$ & 2.23$\times$ & \textbf{3.22$\times$} \\
+MR\_HEAD       & 0.13 & 2.11$\times$ & 2.61$\times$ & 2.65$\times$ & 2.57$\times$ & 2.53$\times$ & 2.67$\times$ & \textbf{2.86$\times$} \\
+MR\_INTERA     & 2.00 & 4.71$\times$ & 3.68$\times$ & 4.05$\times$ & 3.75$\times$ & 3.78$\times$ & 5.04$\times$ & \textbf{5.08$\times$} \\
+DX\_HAND       & 3.98 & 1.99$\times$ & 2.24$\times$ & 2.35$\times$ & 2.26$\times$ & 2.25$\times$ & 2.37$\times$ & \textbf{2.48$\times$} \\
+DX\_CHEST      & 3.84 & 1.43$\times$ & 1.66$\times$ & \textbf{1.82$\times$} & 1.65$\times$ & 1.63$\times$ & 1.63$\times$ & 1.70$\times$ \\
+CR\_THORAX     & 7.43 & 1.61$\times$ & 1.82$\times$ & 1.81$\times$ & 1.84$\times$ & 1.83$\times$ & 1.81$\times$ & \textbf{1.90$\times$} \\
+PET1           & 0.13 & 2.37$\times$ & 2.74$\times$ & 2.81$\times$ & 2.64$\times$ & 2.52$\times$ & 3.02$\times$ & \textbf{3.21$\times$} \\
+PET2           & 0.13 & 3.39$\times$ & 3.39$\times$ & 3.48$\times$ & 3.16$\times$ & 2.58$\times$ & 4.37$\times$ & \textbf{4.74$\times$} \\
+CT\_LUNG       & 0.50 & 2.40$\times$ & 2.73$\times$ & 2.45$\times$ & 2.50$\times$ & 2.25$\times$ & 2.67$\times$ & \textbf{3.15$\times$} \\
+CT\_PANCREAS   & 0.50 & 2.09$\times$ & 2.36$\times$ & 1.76$\times$ & 2.18$\times$ & 1.98$\times$ & 1.85$\times$ & \textbf{2.70$\times$} \\
+MR\_BRAIN      & 0.16 & 6.17$\times$ & 7.27$\times$ & 6.75$\times$ & 7.31$\times$ & 7.24$\times$ & 7.62$\times$ & \textbf{8.46$\times$} \\
+MR\_BREAST     & 0.13 & 3.31$\times$ & 4.01$\times$ & 3.94$\times$ & 4.00$\times$ & 3.91$\times$ & 4.10$\times$ & \textbf{4.48$\times$} \\
+MR\_PROSTATE   & 0.20 & 2.04$\times$ & 2.30$\times$ & 2.34$\times$ & 2.28$\times$ & 2.26$\times$ & 2.49$\times$ & \textbf{2.65$\times$} \\
+PET\_PSMA      & 0.08 & 11.88$\times$ & 10.12$\times$ & 7.67$\times$ & 1.20$\times$ & 1.18$\times$ & 13.91$\times$ & \textbf{15.78$\times$} \\
+PET\_LUNG      & 0.08 & 4.56$\times$ & 2.97$\times$ & 2.97$\times$ & 1.00$\times$ & 1.03$\times$ & 5.21$\times$ & \textbf{5.62$\times$} \\
 \midrule
-\textbf{Geomean} & --- & \textbf{3.03$\times$} & \textbf{3.46$\times$} & \textbf{3.41$\times$} & \textbf{3.44$\times$} & \textbf{3.38$\times$} & \textbf{3.45$\times$} & \textbf{3.82$\times$} \\
+\textbf{Geomean} & --- & \textbf{3.06$\times$} & \textbf{3.36$\times$} & \textbf{3.21$\times$} & \textbf{3.04$\times$} & \textbf{2.95$\times$} & \textbf{3.42$\times$} & \textbf{3.84$\times$} \\
 \bottomrule
 \end{tabular}
 \end{table*}
@@ -585,12 +627,14 @@ XA1  & 2.00 & 4.37$\times$ & 5.01$\times$ & 4.94$\times$ & 5.04$\times$ & 5.03$\
 MIC encodes faster than the others on most images, on both platforms,
 because its encoder is a single pass (predict, run-length, table-driven
 entropy code) while HTJ2K and JPEG-LS do more work per pixel. On
-\textbf{ARM64}, MIC is fastest on all 21 images: roughly 1.9--3.2$\times$ HTJ2K,
-3--7$\times$ JPEG-LS, and 35--240$\times$ Delta + Zstandard (whose max-level
-LZ77 search accounts for its low throughput). On \textbf{AMD64}, MIC is fastest
-on 18 of 21; HTJ2K narrowly leads on the two largest mammography images and one
-radiography image, because the AMD64 baselines are themselves heavily
-vectorized.
+\textbf{ARM64}, MIC is fastest on 38 of 39 images: roughly 1.0--3.3$\times$
+HTJ2K, 1.0--7.1$\times$ JPEG-LS, and 30--320$\times$ Delta + Zstandard (whose
+max-level LZ77 search accounts for its low throughput); HTJ2K edges ahead only
+on the tiny PET\_LUNG study. On \textbf{AMD64}, MIC is fastest on 32 of 39;
+HTJ2K leads on the two largest mammography images, one radiography image, and
+four of the smaller new-corpus studies, because the AMD64 baselines are
+themselves heavily vectorized and per-image table-build overhead weighs more on
+tiny images.
 Table~\ref{tab:enc} gives the per-image encoding throughput.
 
 \begin{table*}[htbp]
@@ -606,29 +650,47 @@ platform.}
 \cmidrule(lr){2-5}\cmidrule(lr){6-9}
 Image & MIC & $\Delta$+Zstd & HTJ2K & JPEG-LS & MIC & $\Delta$+Zstd & HTJ2K & JPEG-LS \\
 \midrule
-MR   & \textbf{504}   &  8 & 273 &  97 & \textbf{338} &  5 & 229          &  62 \\
-CT   & \textbf{529}   &  8 & 200 & 139 & \textbf{292} &  5 & 206          &  97 \\
-CR   & \textbf{569}   &  3 & 204 & 115 & \textbf{322} &  2 & 284          &  75 \\
-XR   & \textbf{690}   &  3 & 248 & 125 & \textbf{405} &  3 & 250          &  84 \\
-MG1  & \textbf{1{,}168} & 14 & 456 & 315 & 546          &  8 & \textbf{647} & 209 \\
-MG2  & \textbf{1{,}172} & 14 & 454 & 315 & 541          &  8 & \textbf{646} & 209 \\
-MG3  & \textbf{706}   &  3 & 234 & 143 & \textbf{332} &  2 & 251          & 104 \\
-MG4  & \textbf{993}   &  7 & 373 & 215 & \textbf{431} &  6 & 415          & 150 \\
-CT1  & \textbf{576}   & 11 & 238 & 178 & \textbf{329} &  7 & 277          & 125 \\
-CT2  & \textbf{561}   &  8 & 207 & 172 & \textbf{286} &  5 & 266          & 125 \\
-MG-N & \textbf{718}   &  2 & 235 & 143 & \textbf{339} &  2 & 243          & 104 \\
-MR1  & \textbf{677}   & 11 & 215 & 120 & \textbf{344} &  6 & 244          &  86 \\
-MR2  & \textbf{737}   &  9 & 231 & 131 & \textbf{397} &  4 & 300          &  84 \\
-MR3  & \textbf{901}   & 22 & 299 & 187 & \textbf{428} & 12 & 353          & 123 \\
-MR4  & \textbf{711}   &  8 & 228 & 175 & \textbf{358} &  6 & 318          & 141 \\
-NM1  & \textbf{663}   &  7 & 247 & 170 & \textbf{336} &  5 & 312          & 116 \\
-RG1  & \textbf{659}   &  5 & 246 &  95 & \textbf{392} &  4 & 250          &  65 \\
-RG2  & \textbf{811}   &  6 & 271 & 151 & \textbf{416} &  3 & 356          &  99 \\
-RG3  & \textbf{762}   &  6 & 285 & 189 & 397          &  4 & \textbf{407} & 126 \\
-SC1  & \textbf{765}   &  6 & 256 & 223 & \textbf{407} &  4 & 309          & 168 \\
-XA1  & \textbf{693}   &  7 & 232 & 152 & \textbf{358} &  4 & 310          &  97 \\
+MR             & \textbf{457} & 7 & 236 & 91 & \textbf{344} & 5 & 246 & 62 \\
+CT             & \textbf{476} & 7 & 183 & 126 & \textbf{280} & 5 & 207 & 97 \\
+CR             & \textbf{525} & 2 & 186 & 110 & \textbf{322} & 2 & 286 & 75 \\
+XR             & \textbf{661} & 3 & 229 & 113 & \textbf{400} & 4 & 256 & 84 \\
+MG1            & \textbf{1{,}057} & 11 & 414 & 277 & 532 & 8 & \textbf{632} & 211 \\
+MG2            & \textbf{1{,}047} & 12 & 407 & 284 & 552 & 8 & \textbf{629} & 209 \\
+MG3            & \textbf{639} & 2 & 211 & 132 & \textbf{352} & 2 & 245 & 104 \\
+MG4            & \textbf{883} & 5 & 342 & 196 & \textbf{457} & 6 & 408 & 151 \\
+CT1            & \textbf{615} & 9 & 243 & 176 & \textbf{321} & 7 & 271 & 125 \\
+CT2            & \textbf{536} & 7 & 204 & 172 & \textbf{285} & 5 & 271 & 124 \\
+MG-N           & \textbf{639} & 2 & 214 & 140 & \textbf{358} & 2 & 248 & 104 \\
+MR1            & \textbf{616} & 9 & 205 & 114 & \textbf{367} & 6 & 241 & 86 \\
+MR2            & \textbf{685} & 7 & 216 & 118 & \textbf{409} & 4 & 309 & 85 \\
+MR3            & \textbf{768} & 19 & 264 & 167 & \textbf{441} & 12 & 354 & 123 \\
+MR4            & \textbf{585} & 7 & 212 & 163 & \textbf{367} & 5 & 312 & 142 \\
+NM1            & \textbf{633} & 6 & 208 & 162 & \textbf{340} & 5 & 313 & 115 \\
+RG1            & \textbf{595} & 4 & 218 & 84 & \textbf{396} & 5 & 252 & 66 \\
+RG2            & \textbf{737} & 4 & 263 & 151 & \textbf{425} & 3 & 360 & 100 \\
+RG3            & \textbf{757} & 6 & 276 & 183 & 389 & 4 & \textbf{412} & 126 \\
+SC1            & \textbf{667} & 5 & 225 & 203 & \textbf{416} & 4 & 306 & 169 \\
+XA1            & \textbf{612} & 5 & 203 & 133 & \textbf{356} & 4 & 303 & 98 \\
+CT\_BRAIN      & \textbf{352} & 5 & 168 & 147 & 239 & 4 & \textbf{253} & 112 \\
+CT\_ANKLE      & \textbf{955} & 15 & 290 & 327 & \textbf{450} & 11 & 358 & 261 \\
+CT\_ORT        & \textbf{644} & 10 & 198 & 138 & \textbf{350} & 7 & 269 & 112 \\
+CT\_CHEST      & \textbf{463} & 6 & 177 & 133 & \textbf{267} & 4 & 234 & 100 \\
+MR\_HEAD       & \textbf{430} & 6 & 211 & 106 & \textbf{288} & 4 & 252 & 65 \\
+MR\_INTERA     & \textbf{415} & 4 & 180 & 115 & \textbf{269} & 3 & 268 & 89 \\
+DX\_HAND       & \textbf{587} & 4 & 218 & 102 & \textbf{378} & 3 & 261 & 65 \\
+DX\_CHEST      & \textbf{636} & 6 & 209 & 109 & \textbf{389} & 6 & 241 & 77 \\
+CR\_THORAX     & \textbf{585} & 4 & 226 & 91 & \textbf{397} & 4 & 261 & 68 \\
+PET1           & \textbf{479} & 7 & 240 & 129 & \textbf{295} & 5 & 252 & 111 \\
+PET2           & \textbf{550} & 6 & 236 & 145 & \textbf{269} & 4 & 256 & 103 \\
+CT\_LUNG       & \textbf{586} & 10 & 195 & 141 & \textbf{337} & 7 & 258 & 110 \\
+CT\_PANCREAS   & \textbf{454} & 7 & 193 & 130 & \textbf{292} & 5 & 240 & 98 \\
+MR\_BRAIN      & \textbf{607} & 7 & 229 & 191 & 338 & 6 & \textbf{351} & 141 \\
+MR\_BREAST     & \textbf{522} & 5 & 241 & 141 & \textbf{292} & 4 & 290 & 96 \\
+MR\_PROSTATE   & \textbf{465} & 8 & 195 & 97 & \textbf{313} & 6 & 250 & 66 \\
+PET\_PSMA      & \textbf{434} & 14 & 423 & 426 & 296 & 10 & \textbf{377} & 364 \\
+PET\_LUNG      & 232 & 6 & \textbf{245} & 235 & 144 & 5 & \textbf{260} & 167 \\
 \midrule
-\textbf{Geomean} & \textbf{740} & \textbf{7} & \textbf{273} & \textbf{161} & \textbf{376} & \textbf{4} & \textbf{311} & \textbf{110} \\
+\textbf{Geomean} & \textbf{582} & \textbf{6} & \textbf{231} & \textbf{148} & \textbf{343} & \textbf{5} & \textbf{293} & \textbf{110} \\
 \bottomrule
 \end{tabular}
 \end{table*}
@@ -640,20 +702,22 @@ FSE loop (one lookup, one bit read, one add) with no hard-to-predict branches.
 HTJ2K and JPEG-LS both have data-dependent branches that cause CPU
 mispredictions. Zstandard is the most comparable codec (same predictor, also
 uses FSE) but works on bytes, so it pays the 2$\times$ byte-splitting cost on
-deep data. On \textbf{ARM64}, MIC is fastest on 20 of 21 images (Zstandard is
-faster only on CT, by 1.3\%): roughly 1.5--2.6$\times$ HTJ2K, 1.1--1.7$\times$
-Zstandard, and 2.0--4.5$\times$ JPEG-LS. On \textbf{AMD64}, MIC is fastest on
-all 21 images, from marginally ahead on mammography up to 1.62$\times$ on
-X-ray; switching from four to eight states (plus the AVX-512 widening of the
-post-entropy stages) is what turned the few remaining close cases into MIC
-wins.
+deep data. On \textbf{ARM64}, MIC is fastest on all 39 images: roughly
+1.2--2.1$\times$ HTJ2K, 1.0--2.0$\times$ Zstandard, and 1.1--5.1$\times$
+JPEG-LS, with the largest margins on the smaller images. On \textbf{AMD64}, MIC
+is fastest on 36 of 39 images; on the three exceptions (CT\_BRAIN, MR\_INTERA,
+and the tiny PET\_LUNG study) in-process Zstandard is marginally faster. Across
+its wins MIC runs about 1.0--1.8$\times$ HTJ2K and 1.9--7.1$\times$ JPEG-LS, and
+stays within 0.7--1.8$\times$ of Zstandard; switching from four to eight states
+(plus the AVX-512 widening of the post-entropy stages) is what turned several
+remaining close cases into MIC wins.
 
-MIC therefore delivers both \textbf{a better ratio than Zstandard on every
-image} and \textbf{faster decoding on nearly every image}, which reflects the
-16-bit-native design. JPEG-LS retains about a 10\% ratio advantage, so the
-choice between them comes down to decode speed versus storage cost. Per-image
-numbers are in Table~\ref{tab:decomp}, and the entropy stage in isolation is in
-Table~\ref{tab:fse-combined}.
+MIC therefore delivers both \textbf{a better ratio than Zstandard on most
+images} (34 of 39) and \textbf{faster decoding on nearly every image}, which
+reflects the 16-bit-native design. JPEG-LS retains about a 14\% ratio
+advantage, so the choice between them comes down to decode speed versus storage
+cost. Per-image numbers are in Table~\ref{tab:decomp}, and the entropy stage in
+isolation is in Table~\ref{tab:fse-combined}.
 
 \begin{table*}[htbp]
 \centering
@@ -669,29 +733,47 @@ each platform.}
 \cmidrule(lr){2-5}\cmidrule(lr){6-9}
 Image & MIC & $\Delta$+Zstd & HTJ2K & JPEG-LS & MIC & $\Delta$+Zstd & HTJ2K & JPEG-LS \\
 \midrule
-MR   & \textbf{564} & 331          & 301 & 146 & \textbf{552} & 357 & 439 &  91 \\
-CT   & 466          & \textbf{472} & 356 & 187 & \textbf{453} & 384 & 329 & 111 \\
-CR   & \textbf{692} & 564          & 367 & 206 & \textbf{566} & 475 & 439 & 123 \\
-XR   & \textbf{655} & 572          & 366 & 150 & \textbf{617} & 508 & 386 &  88 \\
-MG1  & \textbf{829} & 691          & 681 & 547 & \textbf{913} & 599 & 907 & 332 \\
-MG2  & \textbf{873} & 684          & 686 & 557 & \textbf{920} & 599 & 896 & 333 \\
-MG3  & \textbf{678} & 473          & 362 & 201 & \textbf{556} & 358 & 390 & 117 \\
-MG4  & \textbf{815} & 581          & 533 & 259 & \textbf{676} & 466 & 611 & 157 \\
-CT1  & \textbf{571} & 502          & 373 & 238 & \textbf{525} & 425 & 390 & 143 \\
-CT2  & \textbf{648} & 575          & 372 & 222 & \textbf{512} & 456 & 383 & 133 \\
-MG-N & \textbf{657} & 469          & 360 & 201 & \textbf{545} & 355 & 391 & 117 \\
-MR1  & \textbf{681} & 437          & 354 & 154 & \textbf{603} & 384 & 397 &  94 \\
-MR2  & \textbf{747} & 505          & 390 & 224 & \textbf{644} & 464 & 491 & 132 \\
-MR3  & \textbf{859} & 507          & 453 & 329 & \textbf{773} & 485 & 543 & 192 \\
-MR4  & \textbf{775} & 523          & 304 & 230 & \textbf{632} & 480 & 446 & 153 \\
-NM1  & \textbf{866} & 595          & 404 & 277 & \textbf{598} & 486 & 467 & 172 \\
-RG1  & \textbf{561} & 413          & 354 & 126 & \textbf{550} & 347 & 363 &  80 \\
-RG2  & \textbf{755} & 574          & 408 & 255 & \textbf{730} & 497 & 535 & 154 \\
-RG3  & \textbf{740} & 655          & 469 & 320 & \textbf{723} & 552 & 628 & 196 \\
-SC1  & \textbf{696} & 587          & 384 & 280 & \textbf{690} & 484 & 456 & 183 \\
-XA1  & \textbf{759} & 611          & 388 & 278 & \textbf{688} & 534 & 477 & 165 \\
+MR             & \textbf{649} & 389 & 328 & 137 & \textbf{614} & 360 & 453 & 91 \\
+CT             & \textbf{495} & 406 & 299 & 158 & \textbf{444} & 393 & 329 & 110 \\
+CR             & \textbf{580} & 527 & 316 & 181 & \textbf{570} & 479 & 445 & 124 \\
+XR             & \textbf{668} & 512 & 324 & 131 & \textbf{626} & 509 & 393 & 88 \\
+MG1            & \textbf{762} & 685 & 612 & 481 & \textbf{916} & 596 & 913 & 336 \\
+MG2            & \textbf{753} & 692 & 622 & 492 & \textbf{942} & 599 & 902 & 334 \\
+MG3            & \textbf{600} & 433 & 314 & 175 & \textbf{547} & 362 & 392 & 118 \\
+MG4            & \textbf{788} & 504 & 508 & 246 & \textbf{686} & 469 & 634 & 158 \\
+CT1            & \textbf{600} & 450 & 357 & 224 & \textbf{535} & 432 & 389 & 142 \\
+CT2            & \textbf{570} & 471 & 342 & 212 & \textbf{522} & 458 & 383 & 131 \\
+MG-N           & \textbf{600} & 408 & 289 & 180 & \textbf{549} & 357 & 398 & 118 \\
+MR1            & \textbf{734} & 365 & 342 & 149 & \textbf{586} & 381 & 392 & 93 \\
+MR2            & \textbf{700} & 445 & 363 & 211 & \textbf{682} & 460 & 486 & 131 \\
+MR3            & \textbf{839} & 523 & 432 & 289 & \textbf{742} & 497 & 520 & 192 \\
+MR4            & \textbf{692} & 466 & 326 & 220 & \textbf{664} & 496 & 433 & 152 \\
+NM1            & \textbf{778} & 499 & 384 & 260 & \textbf{597} & 515 & 485 & 171 \\
+RG1            & \textbf{469} & 383 & 318 & 123 & \textbf{547} & 340 & 363 & 80 \\
+RG2            & \textbf{652} & 510 & 383 & 225 & \textbf{716} & 503 & 544 & 154 \\
+RG3            & \textbf{685} & 642 & 432 & 294 & \textbf{719} & 564 & 641 & 195 \\
+SC1            & \textbf{699} & 511 & 366 & 263 & \textbf{673} & 483 & 457 & 184 \\
+XA1            & \textbf{662} & 501 & 346 & 244 & \textbf{670} & 541 & 501 & 165 \\
+CT\_BRAIN      & \textbf{528} & 466 & 326 & 190 & 420 & \textbf{477} & 354 & 122 \\
+CT\_ANKLE      & \textbf{853} & 587 & 452 & 426 & \textbf{774} & 562 & 537 & 282 \\
+CT\_ORT        & \textbf{538} & 442 & 348 & 190 & \textbf{565} & 430 & 384 & 124 \\
+CT\_CHEST      & \textbf{500} & 445 & 297 & 178 & \textbf{446} & 428 & 333 & 110 \\
+MR\_HEAD       & \textbf{595} & 372 & 280 & 167 & \textbf{679} & 371 & 406 & 100 \\
+MR\_INTERA     & \textbf{590} & 563 & 304 & 178 & 454 & \textbf{527} & 436 & 133 \\
+DX\_HAND       & \textbf{500} & 414 & 316 & 147 & \textbf{570} & 416 & 362 & 101 \\
+DX\_CHEST      & \textbf{476} & 352 & 307 & 121 & \textbf{547} & 349 & 358 & 83 \\
+CR\_THORAX     & \textbf{552} & 403 & 346 & 129 & \textbf{561} & 365 & 365 & 84 \\
+PET1           & \textbf{732} & 416 & 377 & 197 & \textbf{679} & 384 & 389 & 120 \\
+PET2           & \textbf{656} & 515 & 381 & 227 & \textbf{487} & 438 & 389 & 141 \\
+CT\_LUNG       & \textbf{522} & 316 & 348 & 189 & \textbf{534} & 420 & 383 & 122 \\
+CT\_PANCREAS   & \textbf{517} & 451 & 316 & 172 & \textbf{439} & 390 & 337 & 110 \\
+MR\_BRAIN      & \textbf{866} & 567 & 422 & 375 & \textbf{708} & 514 & 641 & 221 \\
+MR\_BREAST     & \textbf{640} & 545 & 350 & 221 & \textbf{759} & 449 & 510 & 156 \\
+MR\_PROSTATE   & \textbf{679} & 422 & 353 & 165 & \textbf{545} & 386 & 408 & 103 \\
+PET\_PSMA      & \textbf{759} & 678 & 475 & 684 & \textbf{747} & 655 & 539 & 395 \\
+PET\_LUNG      & \textbf{502} & 498 & 283 & 278 & 365 & \textbf{508} & 363 & 170 \\
 \midrule
-\textbf{Geomean} & \textbf{733} & \textbf{557} & \textbf{386} & \textbf{227} & \textbf{602} & \textbf{501} & \textbf{475} & \textbf{144} \\
+\textbf{Geomean} & \textbf{631} & \textbf{473} & \textbf{359} & \textbf{215} & \textbf{598} & \textbf{452} & \textbf{445} & \textbf{140} \\
 \bottomrule
 \end{tabular}
 \end{table*}
@@ -701,7 +783,8 @@ XA1  & \textbf{759} & 611          & 388 & 278 & \textbf{688} & 534 & 477 & 165 
 \caption{FSE decompression throughput (MB/s) for representative modalities,
 single-thread pure-Go decoder. Increasing the number of independent state
 chains exposes more instruction-level parallelism to the out-of-order
-engine.}
+engine. Per-image rows are ten representative modalities; both geometric
+means are over all 39 images.}
 \label{tab:fse-combined}
 \scriptsize
 \setlength{\tabcolsep}{4pt}
@@ -711,17 +794,19 @@ engine.}
 \cmidrule(lr){2-4}\cmidrule(lr){5-7}
 Image & 1-st & 4-st & 8-st & 1-st & 4-st & 8-st \\
 \midrule
-MR   &   612 &   953 &   765 &   636 &   899 &   759 \\
-CT   &   776 & 1,872 & 1,729 &   974 &   986 &   953 \\
-CR   & 3,051 & 5,749 & 5,521 & 1,426 & 1,581 & 1,638 \\
-XR   & 3,657 & 6,072 & 5,807 & 1,939 & 1,890 & 2,248 \\
-MG1  & 3,604 & 4,557 & 5,887 & 2,075 & 1,521 & 1,753 \\
-MG-N & 3,588 & 6,378 & 6,307 & 1,714 & 2,294 & 2,473 \\
-NM1  & 1,798 & 2,535 & 2,740 & 1,091 & 1,274 & 1,522 \\
-RG1  & 1,786 & 3,492 & 5,412 & 1,198 & 1,717 & 2,104 \\
+MR       & 1,066 & 1,576 & 1,068 &   656 & 1,007 &   847 \\
+CT       & 1,001 & 1,549 & 2,142 &   972 & 1,034 & 1,362 \\
+CR       & 2,941 & 4,882 & 6,245 & 1,456 & 1,844 & 1,709 \\
+XR       & 3,597 & 6,081 & 6,030 & 1,745 & 2,341 & 2,014 \\
+MG1      & 3,558 & 4,865 & 4,885 & 2,216 & 1,487 & 1,975 \\
+MG-N     & 3,949 & 6,647 & 6,037 & 1,940 & 2,545 & 2,415 \\
+NM1      & 1,971 & 2,661 & 2,570 &   917 & 1,346 & 1,356 \\
+RG1      & 1,768 & 4,356 & 5,332 & 1,239 & 1,709 & 1,869 \\
+DX\_HAND & 2,120 & 3,163 & 4,816 & 1,245 & 1,833 & 1,520 \\
+PET1     & 1,105 & 1,252 & 1,530 &   575 &   763 &   616 \\
 \midrule
-\textbf{Geomean (21)} & \textbf{2,349} & \textbf{3,422} & \textbf{3,667} &
-\textbf{1,464} & \textbf{1,575} & \textbf{1,614} \\
+\textbf{Geomean (39)} & \textbf{1,742} & \textbf{2,372} & \textbf{2,492} &
+\textbf{1,093} & \textbf{1,228} & \textbf{1,246} \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -745,20 +830,21 @@ configuration on this dataset.
 
 MIC can also split an image into horizontal strips and decode them on
 separate threads. This scales nearly linearly up to four threads on both
-platforms and keeps scaling to eight threads on images above ${\sim}5$\,MB,
-hitting \textbf{4--4.6\,GB/s} on the largest mammography images. Small images
-do not benefit: below about half a megabyte, thread setup costs more than it
-saves. We report this separately because the other codecs run single-threaded
-in our pipeline, so a direct comparison would not be fair.
+platforms and keeps scaling to eight threads on images above ${\sim}1$\,MB,
+hitting about \textbf{4.3\,GB/s} on the largest mammography images on ARM64.
+Small images do not benefit: thread setup costs more than it saves, and on the
+two 0.08\,MB PET images the strips fall back toward raw storage, so strip
+parallelism does not apply. We report this separately because the other codecs
+run single-threaded in our pipeline, so a direct comparison would not be fair.
 Table~\ref{tab:pics} gives the per-image strip-parallel numbers.
 
 \begin{table*}[htbp]
 \centering
 \caption{Multi-threaded decompression throughput (MB/s) for MIC's
 strip-parallel mode. The ``MIC'' column reproduces the single-threaded
-baseline from Table~\ref{tab:decomp} exactly; $N$-strip columns decode the
-same compressed bytes in $N$ parallel threads. The MR image is too small
-for 8-way parallelism on both platforms ($^\dagger$).}
+eight-state baseline from Table~\ref{tab:decomp} exactly; $N$-strip columns
+decode the same compressed bytes in $N$ parallel threads. Both ARM64 and AMD64
+columns cover all 39 images.}
 \label{tab:pics}
 \scriptsize
 \begin{tabular}{l|rrrr|rrrr}
@@ -767,29 +853,55 @@ for 8-way parallelism on both platforms ($^\dagger$).}
 \cmidrule(lr){2-5}\cmidrule(lr){6-9}
 Image & MIC & 2-strip & 4-strip & 8-strip & MIC & 2-strip & 4-strip & 8-strip \\
 \midrule
-MR   & 564   & 663   & 894     & 702\,$^\dagger$   & 552   & 329     & 367     & 294\,$^\dagger$ \\
-CT   & 466   & 624   & 1{,}157 & 1{,}446           & 453   & 398     & 633     & 714 \\
-CR   & 692   & 1{,}052 & 1{,}976 & 3{,}605         & 566   & 758     & 1{,}320 & 2{,}169 \\
-XR   & 655   & 1{,}087 & 2{,}024 & 3{,}794         & 617   & 793     & 1{,}515 & 2{,}579 \\
-MG1  & 829   & 1{,}529 & 2{,}529 & 4{,}443         & 913   & 1{,}317 & 1{,}951 & 2{,}890 \\
-MG2  & 873   & 1{,}417 & 2{,}506 & 4{,}585         & 920   & 1{,}356 & 1{,}971 & 3{,}026 \\
-MG3  & 678   & 1{,}112 & 1{,}911 & 3{,}820         & 556   & 838     & 1{,}449 & 2{,}767 \\
-MG4  & 815   & 1{,}326 & 2{,}345 & 4{,}348         & 676   & 1{,}207 & 1{,}897 & 3{,}126 \\
-CT1  & 571   & 819   & 1{,}247 & 1{,}525           & 525   & 458     & 703     & 725 \\
-CT2  & 648   & 864   & 1{,}260 & 1{,}473           & 512   & 481     & 734     & 719 \\
-MG-N & 657   & 1{,}147 & 2{,}027 & 3{,}930         & 545   & 913     & 1{,}537 & 2{,}819 \\
-MR1  & 681   & 977   & 1{,}460 & 1{,}851           & 603   & 504     & 761     & 764 \\
-MR2  & 747   & 1{,}137 & 1{,}911 & 3{,}103         & 644   & 778     & 1{,}171 & 1{,}534 \\
-MR3  & 859   & 1{,}205 & 1{,}693 & 2{,}089         & 773   & 591     & 788     & 835 \\
-MR4  & 775   & 997   & 1{,}469 & 1{,}757           & 632   & 540     & 796     & 804 \\
-NM1  & 866   & 1{,}147 & 1{,}682 & 2{,}133         & 598   & 523     & 824     & 762 \\
-RG1  & 561   & 677   & 1{,}203 & 2{,}150           & 550   & 603     & 1{,}101 & 1{,}890 \\
-RG2  & 755   & 1{,}229 & 2{,}156 & 3{,}816         & 730   & 916     & 1{,}473 & 2{,}268 \\
-RG3  & 740   & 1{,}335 & 2{,}343 & 4{,}168         & 723   & 971     & 1{,}618 & 2{,}730 \\
-SC1  & 696   & 1{,}311 & 2{,}206 & 3{,}971         & 690   & 1{,}024 & 1{,}673 & 2{,}541 \\
-XA1  & 759   & 1{,}214 & 1{,}881 & 3{,}191         & 688   & 792     & 1{,}246 & 1{,}748 \\
+MR                   & 649 & 698 & 939 & 1{,}033 & 614 & 281 & 369 & 291\,$^\dagger$ \\
+CT                   & 495 & 511 & 987 & 1{,}549 & 444 & 379 & 641 & 736 \\
+CR                   & 580 & 865 & 1{,}771 & 3{,}227 & 570 & 768 & 1{,}404 & 2{,}236 \\
+XR                   & 668 & 888 & 1{,}728 & 3{,}197 & 626 & 787 & 1{,}408 & 2{,}252 \\
+MG1                  & 762 & 1{,}415 & 2{,}403 & 4{,}342 & 916 & 1{,}330 & 1{,}924 & 3{,}575 \\
+MG2                  & 753 & 1{,}369 & 2{,}226 & 4{,}109 & 942 & 1{,}302 & 1{,}698 & 3{,}011 \\
+MG3                  & 600 & 934 & 1{,}763 & 3{,}158 & 547 & 868 & 1{,}597 & 2{,}781 \\
+MG4                  & 788 & 1{,}263 & 2{,}185 & 4{,}120 & 686 & 1{,}258 & 1{,}957 & 3{,}107 \\
+CT1                  & 600 & 779 & 1{,}178 & 1{,}639 & 535 & 477 & 743 & 797 \\
+CT2                  & 570 & 773 & 1{,}249 & 1{,}296 & 522 & 475 & 718 & 806 \\
+MG-N                 & 600 & 988 & 1{,}852 & 3{,}569 & 549 & 871 & 1{,}644 & 2{,}913 \\
+MR1                  & 734 & 931 & 1{,}375 & 1{,}898 & 586 & 517 & 729 & 827 \\
+MR2                  & 700 & 1{,}003 & 1{,}699 & 2{,}750 & 682 & 786 & 1{,}064 & 1{,}476 \\
+MR3                  & 839 & 919 & 1{,}381 & 2{,}035 & 742 & 627 & 861 & 853 \\
+MR4                  & 692 & 954 & 1{,}301 & 2{,}063 & 664 & 573 & 813 & 877 \\
+NM1                  & 778 & 964 & 1{,}410 & 1{,}868 & 597 & 561 & 777 & 771 \\
+RG1                  & 469 & 586 & 1{,}068 & 1{,}964 & 547 & 626 & 1{,}113 & 1{,}833 \\
+RG2                  & 652 & 1{,}095 & 1{,}887 & 3{,}269 & 716 & 922 & 1{,}523 & 2{,}494 \\
+RG3                  & 685 & 1{,}081 & 2{,}027 & 3{,}289 & 719 & 991 & 1{,}596 & 2{,}504 \\
+SC1                  & 699 & 1{,}171 & 2{,}005 & 3{,}174 & 673 & 1{,}042 & 1{,}690 & 2{,}598 \\
+XA1                  & 662 & 973 & 1{,}692 & 2{,}404 & 670 & 806 & 1{,}170 & 1{,}443 \\
+CT\_BRAIN            & 528 & 627 & 1{,}025 & 1{,}291 & 420 & 426 & 630 & 681 \\
+CT\_ANKLE            & 853 & 1{,}082 & 1{,}745 & 1{,}713 & 774 & 654 & 869 & 877 \\
+CT\_ORT              & 538 & 679 & 1{,}099 & 1{,}316 & 565 & 485 & 726 & 778 \\
+CT\_CHEST            & 500 & 622 & 1{,}042 & 1{,}354 & 446 & 409 & 633 & 691 \\
+MR\_HEAD             & 595 & 620 & 915 & 880 & 679 & 306 & 417 & 307 \\
+MR\_INTERA           & 590 & 910 & 1{,}575 & 2{,}405 & 454 & 618 & 940 & 1{,}329 \\
+DX\_HAND             & 500 & 605 & 1{,}113 & 2{,}051 & 570 & 619 & 1{,}133 & 1{,}697 \\
+DX\_CHEST            & 476 & 566 & 1{,}003 & 1{,}971 & 547 & 592 & 990 & 1{,}712 \\
+CR\_THORAX           & 552 & 588 & 1{,}128 & 1{,}733 & 561 & 624 & 1{,}141 & 1{,}937 \\
+PET1                 & 732 & 637 & 854 & 854 & 679 & 289 & 406 & 317 \\
+PET2                 & 656 & 669 & 776 & 923 & 487 & 341 & 356 & 320 \\
+CT\_LUNG             & 522 & 689 & 1{,}107 & 1{,}462 & 534 & 468 & 752 & 808 \\
+CT\_PANCREAS         & 517 & 506 & 1{,}018 & 1{,}316 & 439 & 390 & 652 & 688 \\
+MR\_BRAIN            & 866 & 815 & 999 & 1{,}143 & 708 & 435 & 490 & 448 \\
+MR\_BREAST           & 640 & 653 & 920 & 956 & 759 & 288 & 396 & 337 \\
+MR\_PROSTATE         & 679 & 742 & 1{,}093 & 1{,}279 & 545 & 321 & 507 & 455 \\
+PET\_PSMA$^\ddagger$ & 759 & 727 & -- & -- & 747 & 282 & -- & -- \\
+PET\_LUNG$^\ddagger$ & 502 & 359 & -- & -- & 365 & 208 & -- & -- \\
 \bottomrule
 \end{tabular}
+
+\vspace{2pt}
+{\scriptsize $^\dagger$The 130\,KB MR image is too small to benefit from 8-way
+parallelism on AMD64: synchronization overhead exceeds the per-strip work, so
+4-strip is faster than 8-strip. $^\ddagger$On the two 0.08\,MB PET images,
+splitting into four or more strips drives the strip-compressed size to or above
+the single-stream size, so their 4- and 8-strip figures reflect near-raw
+copying rather than entropy decoding and are omitted.}
 \end{table*}
 
 Practical guidance: to decode many small images, use single-threaded MIC
@@ -799,7 +911,7 @@ machine, use strip-parallel mode with four to eight threads.
 \subsection{In the browser}
 
 The JavaScript decoder performs well. Notably, the \textbf{four-state}
-variant is 7--13\% \emph{faster} than eight-state in JavaScript, even on the
+variant runs 6--21\% \emph{faster} than eight-state in JavaScript, even on the
 same hardware where eight states win in C. The reason is the JavaScript engine
 (V8): it can keep four independent chains busy but not eight, so the extra
 chains add overhead without shortening the critical path. The eight-state
@@ -807,8 +919,8 @@ path still works in JavaScript (it lets one decoder accept C-encoded files
 without conversion), but four states is the best configuration for the
 browser.
 
-Concretely, a 9.35\,MB mammography image decodes in 19.8\,ms (473\,MB/s) using
-eight workers with four-state strips. That means a web DICOM viewer can pull
+Concretely, a 9.35\,MB mammography image decodes in 17.1\,ms (547\,MB/s) using
+four-state strips across worker threads. That means a web DICOM viewer can pull
 a \texttt{.mic} file straight from object storage and decode it client-side,
 with no server doing compression or format conversion. (These numbers are from
 Node.js; full in-browser benchmarking is future work.)
@@ -826,13 +938,20 @@ variants. Median over 20 iterations after three warm-up runs.}
 \cmidrule(lr){4-5}\cmidrule(lr){6-7}
 Image & Dimensions & Ratio & ms & MB/s & ms & MB/s \\
 \midrule
-MR  & $256{\times}256$   & 2.35$\times$ &   2.5 &  50 &   3.3 &  38 \\
-CT  & $512{\times}512$   & 2.24$\times$ &  11.9 &  42 &  14.1 &  36 \\
-CR  & $2140{\times}1760$ & 3.69$\times$ & 136.4 &  53 & 151.4 &  47 \\
-MG1 & $2457{\times}1996$ & 8.79$\times$ &  68.1 & 137 &  78.3 & 120 \\
-MG3 & $4774{\times}3064$ & 2.29$\times$ & 514.5 &  54 & 563.7 &  49 \\
+MR\,$^\dagger$ & $256{\times}256$   & 2.35$\times$ &   2.9 &  43 &   2.7 &  46 \\
+CT  & $512{\times}512$   & 2.24$\times$ &  12.3 &  41 &  13.1 &  38 \\
+CR  & $2140{\times}1760$ & 3.69$\times$ & 137.2 &  52 & 165.5 &  43 \\
+MG1 & $2457{\times}1996$ & 8.79$\times$ &  70.4 & 133 &  80.0 & 117 \\
+MG3 & $4774{\times}3064$ & 2.29$\times$ & 560.8 &  50 & 607.1 &  46 \\
+DX\_HAND & $1480{\times}1410$ & 2.24$\times$ &  82.6 &  48 &  96.1 &  41 \\
+PET1 & $256{\times}256$   & 2.74$\times$ &   2.1 &  60 &   2.5 &  50 \\
 \bottomrule
 \end{tabular}
+
+\vspace{2pt}
+{\scriptsize $^\dagger$MR's 0.13\,MB image decodes in under 3\,ms, at the
+JavaScript timing floor; the four-state advantage seen on the larger images
+is within run-to-run noise here.}
 \end{table}
 
 \begin{table}[htbp]
@@ -848,10 +967,11 @@ each variant is reported.}
 \cmidrule(lr){3-4}\cmidrule(lr){5-6}
 Image & Strips &   ms & MB/s &   ms & MB/s \\
 \midrule
-MR  & 4 &   1.1 & 111 &   1.3 &  97 \\
-CT  & 4 &   4.2 & 120 &   4.7 & 108 \\
-CR  & 8 &  33.4 & 215 &  31.8 & 226 \\
-MG1 & 8 &  19.8 & 473 &  20.5 & 457 \\
+MR  & 4 &   0.9 & 134 &   0.9 & 135 \\
+CT  & 4 &   4.1 & 123 &   4.5 & 112 \\
+CR  & 8 &  22.9 & 313 &  28.0 & 257 \\
+MG1 & 8 &  17.1 & 547 &  16.7 & 559 \\
+DX\_HAND & 8 &  17.1 & 233 &  17.8 & 224 \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -863,11 +983,12 @@ MG1 & 8 &  19.8 & 473 &  20.5 & 457 \\
 \subsection{Reading the results together}
 
 Three observations tie the numbers together. First, MIC's \textbf{ratio
-advantage over Zstandard} (5--22\%, 14\% average) comes mainly from working on
-16-bit residuals directly instead of splitting them into bytes, and that same
-choice removes the per-byte branches that slow decoding. Second, on the largest
-mammography images on AMD64, \textbf{HTJ2K's block coder} regains the speed
-lead by amortizing its setup over many pixels; MIC stays within 0--20\% there.
+advantage over Zstandard} (about 10\% in geometric mean, higher on 34 of 39
+images) comes mainly from working on 16-bit residuals directly instead of
+splitting them into bytes, and that same choice removes the per-byte branches
+that slow decoding. Second, on the largest mammography images on AMD64,
+\textbf{HTJ2K's block coder} regains the speed lead by amortizing its setup
+over many pixels; MIC stays within 0--20\% there.
 Third, \textbf{multi-state decoding} is what makes MIC's decoder competitive
 with HTJ2K's vectorized block coder, and it costs nothing in file size.
 
@@ -876,7 +997,7 @@ with HTJ2K's vectorized block coder, and it costs nothing in file size.
 For \textbf{low-latency viewing} (PACS, thumbnails, tomosynthesis playback),
 single-threaded MIC is a sensible default (${\sim}600$--900\,MB/s per request),
 with strip-parallel MIC for one large image at a time. For \textbf{smallest
-archival files}, JPEG-LS keeps a ${\sim}10\%$ better ratio, at the cost of
+archival files}, JPEG-LS keeps a ${\sim}14\%$ better ratio, at the cost of
 decoding 1.6--5.7$\times$ slower on ARM64. Where \textbf{DICOM transfer-syntax
 compatibility} is required, HTJ2K is the appropriate choice, since it is a
 standard and is particularly strong on large mammography images on AMD64. Where
@@ -888,17 +1009,18 @@ A more structured comparison---a Pareto view of ratio vs.\ decode
 speed~\cite{geldreich_pareto,jpegxl_pareto}, plus a weighted decision matrix
 over ratio, speed, platform coverage, and deployment
 ease~\cite{saaty_ahp,sayood}, following deployment taxonomies for DICOM
-compression~\cite{clunie_miit2009,liu2017}---puts MIC and JPEG-LS on the
-efficiency frontier (MIC for throughput, JPEG-LS for ratio), with HTJ2K and
-Zstandard dominated on those two axes. HTJ2K remains the choice whenever
-standard compatibility is a hard requirement that the scoring does not capture.
+compression~\cite{clunie_miit2009,liu2017}---puts MIC, HTJ2K, and JPEG-LS on
+the efficiency frontier (MIC for throughput, JPEG-LS for ratio, HTJ2K in
+between), with Delta + Zstandard dominated by MIC on both axes. HTJ2K remains
+the choice whenever standard compatibility is a hard requirement that the
+scoring does not capture.
 Table~\ref{tab:decision-matrix} reports the weighted matrix.
 
 \begin{table}[htbp]
 \centering
 \caption{Codec selection matrix. Each criterion is normalised so the
 best codec on that row scores~1.00. Quantitative rows are geometric
-means across the 21-image set. Browser compatibility: shipped
+means across the 39-image set. Browser compatibility: shipped
 purpose-built JS or WASM decoder used in production~=~1.00; WASM port of
 the native library used in clinical viewers~=~0.85; no browser
 path~=~0.0. Deployment ease: zero external runtime dependencies~=~1.00;
@@ -913,24 +1035,24 @@ storage, (B)~browser delivery.}
 \toprule
 Criterion & $w_P$ & $w_A$ & $w_B$ & MIC & HTJ2K & JPEG-LS \\
 \midrule
-Compression ratio                & 0.20 & 0.50 & 0.10 & 0.91 & 0.90 & \textbf{1.00} \\
-Decompression throughput (ARM64) & 0.30 & 0.10 & 0.15 & \textbf{1.00} & 0.53 & 0.31 \\
-Encoding throughput (ARM64)      & 0.05 & 0.10 & 0.05 & \textbf{1.00} & 0.37 & 0.22 \\
+Compression ratio                & 0.20 & 0.50 & 0.10 & 0.88 & 0.89 & \textbf{1.00} \\
+Decompression throughput (ARM64) & 0.30 & 0.10 & 0.15 & \textbf{1.00} & 0.57 & 0.34 \\
+Encoding throughput (ARM64)      & 0.05 & 0.10 & 0.05 & \textbf{1.00} & 0.40 & 0.25 \\
 AMD64 native                     & 0.10 & 0.05 & 0.05 & \textbf{1.00} & \textbf{1.00} & \textbf{1.00} \\
 ARM64 native                     & 0.10 & 0.05 & 0.05 & \textbf{1.00} & \textbf{1.00} & \textbf{1.00} \\
 Browser compatibility            & 0.05 & 0.00 & 0.40 & \textbf{1.00} & 0.85 & 0.85 \\
 Deployment ease                  & 0.20 & 0.20 & 0.20 & \textbf{1.00} & 0.70 & 0.70 \\
 \midrule
-\textbf{Weighted score (P) viewer}   & --- & --- & --- & \textbf{0.98} & 0.74 & 0.69 \\
-\textbf{Weighted score (A) archival} & --- & --- & --- & \textbf{0.96} & 0.78 & 0.80 \\
-\textbf{Weighted score (B) browser}  & --- & --- & --- & \textbf{0.99} & 0.78 & 0.74 \\
+\textbf{Weighted score (P) viewer}   & --- & --- & --- & \textbf{0.98} & 0.75 & 0.70 \\
+\textbf{Weighted score (A) archival} & --- & --- & --- & \textbf{0.94} & 0.78 & 0.80 \\
+\textbf{Weighted score (B) browser}  & --- & --- & --- & \textbf{0.99} & 0.77 & 0.74 \\
 \bottomrule
 \end{tabular}
 \end{table}
 
 \subsection{Limitations}
 
-\textbf{Small dataset.} 21 images across nine modalities is varied but far from
+\textbf{Small dataset.} 39 images across eleven modalities is varied but far from
 a clinical archive; broader validation is needed. \textbf{Tuning on the test
 set.} The adaptive table-size thresholds and the predictor choice were informed
 by this dataset; the rules are simple (two thresholds, one predictor), which
@@ -949,10 +1071,10 @@ standardization step.
 
 MIC is a 16-bit-native lossless codec for medical images: spatial prediction,
 16-bit run-length coding, a large-alphabet table-based entropy coder, and a
-multi-state decoder for speed. On 21 DICOM images it reaches an average
-ratio of 3.46$\times$ (tied with HTJ2K, ${\sim}91\%$ of JPEG-LS) while being
-the fastest decoder on 20/21 images on ARM64 and all 21 on AMD64, and the
-fastest encoder on all 21 ARM64 images and 18/21 on AMD64. A 20\,KB JavaScript
+multi-state decoder for speed. On 39 DICOM images it reaches a geometric-mean
+ratio of 3.36$\times$ (within ${\sim}2\%$ of HTJ2K, ${\sim}88\%$ of JPEG-LS)
+while being the fastest decoder on all 39 images on ARM64 and 36/39 on AMD64,
+and the fastest encoder on 38/39 ARM64 images and 32/39 on AMD64. A 20\,KB JavaScript
 decoder and a WebAssembly build show the format can be decoded client-side in a
 browser. Future work: larger multi-hospital datasets; stronger shuffle-based
 baselines; full statistical reporting; an ARM64 vector kernel for the wavelet


### PR DESCRIPTION
Port the expanded benchmark dataset from mic-paper-v9-ieee-tmi.tex into the
plain-language simplified edition. The corpus grows from 21 images / nine
modalities to 39 images / eleven modalities (adds CT, MR, DX, CR, PET, and
breast/prostate MRI studies from GDCM and TCIA collections).

Updated tables (all to v9 source numbers): dataset, compression ratios,
encoding throughput, decompression throughput, FSE microbench, strip-parallel
(PICS), JavaScript single-thread and PICS-JS, and the codec selection matrix.

Updated headline numbers throughout abstract, intro, results, discussion,
limitations, and conclusion:
- MIC geomean ratio 3.46x -> 3.36x; HTJ2K 3.45x -> 3.42x; JPEG-LS 3.82x -> 3.84x
- MIC vs Delta+Zstd: ~10% geomean (better on 34/39) replacing 5-22%/14%
- Decode wins: ARM64 all 39, AMD64 36/39; encode wins ARM64 38/39, AMD64 32/39
- Multi-state FSE speedup: 4-state +36%/+12%, 8-state +5%/+1% (ARM64/AMD64)
- Predictor and Pareto-frontier prose realigned (HTJ2K now on the frontier)

PDF/DOCX artifacts not regenerated (no LaTeX toolchain in this environment).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BxsHH787tpAvy1h1MMASbn